### PR TITLE
--disable-shared builds in the docker images

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -31,7 +31,7 @@ function do_python_build {
         local unicode_flags="--enable-unicode=ucs4"
     fi
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath /opt/$py_ver/lib" ./configure --prefix=/opt/$py_ver --enable-shared $unicode_flags > /dev/null
+    CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath /opt/$py_ver/lib" ./configure --prefix=/opt/$py_ver --disable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
 }


### PR DESCRIPTION
This implements one of the changes for the Docker images pursuant to #31, removing `--enable-shared`.