### PR TITLE
Update OpenSSL to 1.0.2g

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -9,8 +9,8 @@ PY_VERS="2.6.9 2.7.11 3.3.6 3.4.4 3.5.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
-OPENSSL_ROOT=openssl-1.0.2f
-OPENSSL_HASH=932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
+OPENSSL_ROOT=openssl-1.0.2g
+OPENSSL_HASH=b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
 
 # Dependencies for compiling Python that we want to remove from
 # the final image after compiling Python


### PR DESCRIPTION
The download redirection for 1.0.2f is in fact broken at the moment: http://openssl.org/source/openssl-1.0.2f.tar.gz

```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL /source/old/1.0.1/openssl-1.0.2f.tar.gz was not found on this server.</p>
<hr>
<address>Apache/2.4.7 (Ubuntu) Server at openssl.org Port 80</address>
</body></html>
```

This works, however: http://openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz

But it's best to just update, especially since 1.0.2g is a security release. I verified the signature and hash on 1.0.2g locally.