### PR TITLE
Add UCS-2 builds of Python to the docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,14 +51,25 @@ directory for source code.
 The images currently contain:
 
 - CPython 2.6, 2.7, 3.3, 3.4, and 3.5, installed in ``/opt/<version
-  number>``
+  number><soabi flags>``
 - Devel packages for all the libraries that PEP 513 allows you to
   assume are present on the host system
 - The `auditwheel <https://pypi.python.org/pypi/auditwheel>`_ tool
 
+The "soabi flags" used in naming CPython version directories under ``/opt`` are
+`PEP 3149 <https://www.python.org/dev/peps/pep-3149/>`_ ABI flags. Because
+wheels created using a CPython (older than 3.3) built with
+``--enable-unicode=ucs2`` are not compatible with ``--enable-unicode=ucs4``
+interpreters, CPython 2.X builds of both UCS-2 (flags ``m``) and UCS-4 (flags
+``mu``) are provided in ``/opt`` since both are commonly found "in the wild."
+Other less common or virtually unheard of flag combinations (such as
+``--with-pydebug`` (``d``) and ``--without-pymalloc`` (absence of ``m``)) are
+not provided.
+
 It'd be good to put an example of how to use these images here, but
 that isn't written yet. If you want to know, then bug us on the
-mailing list to fill in this section :-).
+mailing list to fill in this section :-). However, one useful tip is that a
+list of all interpreters can be obtained with ``/opt/python/*/bin/python``.
 
 
 The PEP itself

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -66,5 +66,11 @@ yum -y clean all > /dev/null 2>&1
 yum list installed
 
 for PYVER in $PY_VERS; do
-    /opt/$PYVER/bin/python $MY_DIR/manylinux1-check.py
+    soabi_flags_list="m"
+    if [ $(lex_pyver $PYVER) -lt $(lex_pyver 3.3) ]; then
+        soabi_flags_list="mu m"
+    fi
+    for soabi_flags in $soabi_flags_list; do
+        /opt/${PYVER}${soabi_flags}/bin/python $MY_DIR/manylinux1-check.py
+    done
 done

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -65,12 +65,7 @@ yum -y install ${MANYLINUX1_DEPS}
 yum -y clean all > /dev/null 2>&1
 yum list installed
 
-for PYVER in $PY_VERS; do
-    soabi_flags_list="m"
-    if [ $(lex_pyver $PYVER) -lt $(lex_pyver 3.3) ]; then
-        soabi_flags_list="mu m"
-    fi
-    for soabi_flags in $soabi_flags_list; do
-        /opt/${PYVER}${soabi_flags}/bin/python $MY_DIR/manylinux1-check.py
-    done
+# Checks the same interpreters repeatedly, but is more thorough
+for PYTHON in /opt/*/bin/python; do
+    $PYTHON $MY_DIR/manylinux1-check.py
 done

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -53,8 +53,8 @@ tar -xzf patchelf-0.8.tar.gz
 (cd patchelf-0.8 && ./configure && make && make install)
 rm -rf patchelf-0.8.tar.gz patchelf-0.8
 
-/opt/3.5/bin/pip install git+git://github.com/manylinux/auditwheel.git && \
-ln -s /opt/3.5/bin/auditwheel /usr/local/bin/auditwheel
+/opt/3.5m/bin/pip install git+git://github.com/manylinux/auditwheel.git && \
+ln -s /opt/3.5m/bin/auditwheel /usr/local/bin/auditwheel
 
 # Clean up development headers and other unnecessary stuff for
 # final image
@@ -65,7 +65,6 @@ yum -y install ${MANYLINUX1_DEPS}
 yum -y clean all > /dev/null 2>&1
 yum list installed
 
-# Checks the same interpreters repeatedly, but is more thorough
 for PYTHON in /opt/*/bin/python; do
     $PYTHON $MY_DIR/manylinux1-check.py
 done

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -37,7 +37,7 @@ function do_python_build {
         fi
     fi
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath /opt/${py_ver}${soabi_flags}/lib" ./configure --prefix=/opt/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
+    CFLAGS="-Wformat" ./configure --prefix=/opt/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
 }

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -26,12 +26,18 @@ function lex_pyver {
 function do_python_build {
     local py_ver=$1
     check_var $py_ver
-    mkdir -p /opt/$py_ver/lib
+    local soabi_flags=$2
+    check_var $soabi_flags
+    mkdir -p /opt/${py_ver}${soabi_flags}/lib
     if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.3) ]; then
-        local unicode_flags="--enable-unicode=ucs4"
+        if [ $soabi_flags = "mu" ]; then
+            local unicode_flags="--enable-unicode=ucs4"
+        else
+            local unicode_flags="--enable-unicode=ucs2"
+        fi
     fi
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath /opt/$py_ver/lib" ./configure --prefix=/opt/$py_ver --disable-shared $unicode_flags > /dev/null
+    CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath /opt/${py_ver}${soabi_flags}/lib" ./configure --prefix=/opt/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
 }
@@ -43,15 +49,22 @@ function build_python {
     local py_ver2="$(echo $py_ver | cut -d. -f 1,2)"
     check_var $PYTHON_DOWNLOAD_URL
     wget -q $PYTHON_DOWNLOAD_URL/$py_ver/Python-$py_ver.tgz
-    tar -xzf Python-$py_ver.tgz
-    (cd Python-$py_ver && do_python_build $py_ver)
-    if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3) ]; then \
-        ln -s /opt/$py_ver/bin/python3 /opt/$py_ver/bin/python;
-    fi;
-    ln -s /opt/$py_ver/ /opt/$py_ver2
-    /opt/$py_ver/bin/python get-pip.py
-    /opt/$py_ver/bin/pip install wheel
-    rm -rf Python-$py_ver.tgz Python-$py_ver
+    if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.3) ]; then
+        local soabi_flags_list="mu m"
+    fi
+    for soabi_flags in ${soabi_flags_list:-m}; do
+        tar -xzf Python-$py_ver.tgz
+        (cd Python-$py_ver && do_python_build $py_ver $soabi_flags)
+        if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3) ]; then \
+            ln -s /opt/${py_ver}${soabi_flags}/bin/python3 /opt/${py_ver}${soabi_flags}/bin/python;
+        fi;
+        ln -s /opt/${py_ver}${soabi_flags}/ /opt/${py_ver2}${soabi_flags}
+        [ ! -h /opt/${py_ver2} ] && ln -s /opt/${py_ver}${soabi_flags}/ /opt/$py_ver2
+        /opt/${py_ver}${soabi_flags}/bin/python get-pip.py
+        /opt/${py_ver}${soabi_flags}/bin/pip install wheel
+        rm -rf Python-$py_ver
+    done
+    rm -f Python-$py_ver.tgz
 }
 
 

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -28,7 +28,7 @@ function do_python_build {
     check_var $py_ver
     local soabi_flags=$2
     check_var $soabi_flags
-    mkdir -p /opt/${py_ver}${soabi_flags}/lib
+    mkdir -p /opt/python/${py_ver}${soabi_flags}/lib
     if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.3) ]; then
         if [ $soabi_flags = "mu" ]; then
             local unicode_flags="--enable-unicode=ucs4"
@@ -37,7 +37,7 @@ function do_python_build {
         fi
     fi
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" ./configure --prefix=/opt/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
+    CFLAGS="-Wformat" ./configure --prefix=/opt/python/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
 }
@@ -56,12 +56,11 @@ function build_python {
         tar -xzf Python-$py_ver.tgz
         (cd Python-$py_ver && do_python_build $py_ver $soabi_flags)
         if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3) ]; then \
-            ln -s /opt/${py_ver}${soabi_flags}/bin/python3 /opt/${py_ver}${soabi_flags}/bin/python;
+            ln -s /opt/python/${py_ver}${soabi_flags}/bin/python3 /opt/python/${py_ver}${soabi_flags}/bin/python;
         fi;
-        ln -s /opt/${py_ver}${soabi_flags}/ /opt/${py_ver2}${soabi_flags}
-        [ ! -h /opt/${py_ver2} ] && ln -s /opt/${py_ver}${soabi_flags}/ /opt/$py_ver2
-        /opt/${py_ver}${soabi_flags}/bin/python get-pip.py
-        /opt/${py_ver}${soabi_flags}/bin/pip install wheel
+        ln -s /opt/python/${py_ver}${soabi_flags}/ /opt/${py_ver2}${soabi_flags}
+        /opt/python/${py_ver}${soabi_flags}/bin/python get-pip.py
+        /opt/python/${py_ver}${soabi_flags}/bin/pip install wheel
         rm -rf Python-$py_ver
     done
     rm -f Python-$py_ver.tgz


### PR DESCRIPTION
`/opt/<major>` links to the UCS-4 builds, but `/opt/<major><soabi_flags>` and `/opt/<full><soabi_flags>` are the more specific paths:

```console
nate@mjolnir0% docker run --rm natefoo/manylinux1_x86_64 ls -l /opt
total 48
lrwxrwxrwx 1 root root  13 Mar  4 17:23 2.6 -> /opt/2.6.9mu/
drwxr-xr-x 1 root root  36 Mar  4 17:24 2.6.9m
drwxr-xr-x 1 root root  36 Mar  4 17:23 2.6.9mu
lrwxrwxrwx 1 root root  12 Mar  4 17:24 2.6m -> /opt/2.6.9m/
lrwxrwxrwx 1 root root  13 Mar  4 17:23 2.6mu -> /opt/2.6.9mu/
lrwxrwxrwx 1 root root  14 Mar  4 17:26 2.7 -> /opt/2.7.11mu/
drwxr-xr-x 1 root root  36 Mar  4 17:27 2.7.11m
drwxr-xr-x 1 root root  36 Mar  4 17:26 2.7.11mu
lrwxrwxrwx 1 root root  13 Mar  4 17:27 2.7m -> /opt/2.7.11m/
lrwxrwxrwx 1 root root  14 Mar  4 17:26 2.7mu -> /opt/2.7.11mu/
lrwxrwxrwx 1 root root  12 Mar  4 17:29 3.3 -> /opt/3.3.6m/
drwxr-xr-x 1 root root  36 Mar  4 17:29 3.3.6m
lrwxrwxrwx 1 root root  12 Mar  4 17:29 3.3m -> /opt/3.3.6m/
lrwxrwxrwx 1 root root  12 Mar  4 17:31 3.4 -> /opt/3.4.4m/
drwxr-xr-x 1 root root  36 Mar  4 17:31 3.4.4m
lrwxrwxrwx 1 root root  12 Mar  4 17:31 3.4m -> /opt/3.4.4m/
lrwxrwxrwx 1 root root  12 Mar  4 17:33 3.5 -> /opt/3.5.1m/
drwxr-xr-x 1 root root  36 Mar  4 17:33 3.5.1m
lrwxrwxrwx 1 root root  12 Mar  4 17:33 3.5m -> /opt/3.5.1m/
drwxr-xr-x 1 root root  24 Mar  4 17:18 rh
```