### PR TITLE
Python != CPython

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,26 +58,33 @@ directory for source code.
 
 The images currently contain:
 
-- CPython 2.6, 2.7, 3.3, 3.4, and 3.5, installed in ``/opt/<version
-  number><soabi flags>``
+- CPython 2.6, 2.7, 3.3, 3.4, and 3.5, installed in
+  ``/opt/python/<abi-tag>``. The directories are named after the ABI
+  tag for the resulting wheels -- e.g. ``/opt/python/cp27mu`` contains
+  a wide-unicode CPython 2.7 build, and can be used to produce wheels
+  named like ``<pkg>-<version>-py27-cp27mu-manylinux1_<arch>.whl``.
+
 - Devel packages for all the libraries that PEP 513 allows you to
   assume are present on the host system
+
 - The `auditwheel <https://pypi.python.org/pypi/auditwheel>`_ tool
 
-The "soabi flags" used in naming CPython version directories under ``/opt`` are
-`PEP 3149 <https://www.python.org/dev/peps/pep-3149/>`_ ABI flags. Because
-wheels created using a CPython (older than 3.3) built with
-``--enable-unicode=ucs2`` are not compatible with ``--enable-unicode=ucs4``
-interpreters, CPython 2.X builds of both UCS-2 (flags ``m``) and UCS-4 (flags
-``mu``) are provided in ``/opt`` since both are commonly found "in the wild."
-Other less common or virtually unheard of flag combinations (such as
-``--with-pydebug`` (``d``) and ``--without-pymalloc`` (absence of ``m``)) are
-not provided.
+Note that prior to CPython 3.3, there were two ABI-incompatible ways
+of building CPython: ``--enable-unicode=ucs2`` and
+``--enable-unicode=ucs4``. We provide both versions
+(e.g. ``/opt/python/cp27m`` for narrow-unicode, ``/opt/python/cp27mu``
+for wide-unicode). NB: essentially all Linux distributions configure
+CPython in ``mu`` (``--enable-unicode=ucs4``) mode, but
+``--enable-unicode=ucs2`` builds are also encountered in the
+wild. Other less common or virtually unheard of flag combinations
+(such as ``--with-pydebug`` (``d``) and ``--without-pymalloc``
+(absence of ``m``)) are not provided.
 
 It'd be good to put an example of how to use these images here, but
 that isn't written yet. If you want to know, then bug us on the
-mailing list to fill in this section :-). However, one useful tip is that a
-list of all interpreters can be obtained with ``/opt/python/*/bin/python``.
+mailing list to fill in this section :-). However, one useful tip is
+that a list of all interpreters can be obtained with
+``/opt/python/*/bin/python``.
 
 
 The PEP itself

--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,11 @@ directory for source code.
 The images currently contain:
 
 - CPython 2.6, 2.7, 3.3, 3.4, and 3.5, installed in
-  ``/opt/python/<abi-tag>``. The directories are named after the ABI
-  tag for the resulting wheels -- e.g. ``/opt/python/cp27mu`` contains
-  a wide-unicode CPython 2.7 build, and can be used to produce wheels
-  named like ``<pkg>-<version>-py27-cp27mu-manylinux1_<arch>.whl``.
+  ``/opt/python/<python tag>-<abi tag>``. The directories are named
+  after the PEP 425 tags for each environment --
+  e.g. ``/opt/python/cp27-cp27mu`` contains a wide-unicode CPython 2.7
+  build, and can be used to produce wheels named like
+  ``<pkg>-<version>-cp27-cp27mu-<arch>.whl``.
 
 - Devel packages for all the libraries that PEP 513 allows you to
   assume are present on the host system
@@ -72,13 +73,13 @@ The images currently contain:
 Note that prior to CPython 3.3, there were two ABI-incompatible ways
 of building CPython: ``--enable-unicode=ucs2`` and
 ``--enable-unicode=ucs4``. We provide both versions
-(e.g. ``/opt/python/cp27m`` for narrow-unicode, ``/opt/python/cp27mu``
-for wide-unicode). NB: essentially all Linux distributions configure
-CPython in ``mu`` (``--enable-unicode=ucs4``) mode, but
-``--enable-unicode=ucs2`` builds are also encountered in the
-wild. Other less common or virtually unheard of flag combinations
-(such as ``--with-pydebug`` (``d``) and ``--without-pymalloc``
-(absence of ``m``)) are not provided.
+(e.g. ``/opt/python/cp27-cp27m`` for narrow-unicode,
+``/opt/python/cp27-cp27mu`` for wide-unicode). NB: essentially all
+Linux distributions configure CPython in ``mu``
+(``--enable-unicode=ucs4``) mode, but ``--enable-unicode=ucs2`` builds
+are also encountered in the wild. Other less common or virtually
+unheard of flag combinations (such as ``--with-pydebug`` (``d``) and
+``--without-pymalloc`` (absence of ``m``)) are not provided.
 
 It'd be good to put an example of how to use these images here, but
 that isn't written yet. If you want to know, then bug us on the

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -5,7 +5,7 @@
 set -ex
 
 # Python versions to be installed in /opt/$VERSION_NO
-PY_VERS="2.6.9 2.7.11 3.3.6 3.4.4 3.5.1"
+CPYTHON_VERSIONS="2.6.9 2.7.11 3.3.6 3.4.4 3.5.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
@@ -44,7 +44,8 @@ yum -y install bzip2 make git patch unzip bison yasm diffutils \
 # against a recent openssl [see env vars above], which is linked
 # statically. We delete openssl afterwards.)
 build_openssl $OPENSSL_ROOT $OPENSSL_HASH
-build_pythons $PY_VERS
+mkdir -p /opt/python
+build_cpythons $CPYTHON_VERSIONS
 rm -rf /usr/local/ssl
 
 # Install patchelf and auditwheel (latest)
@@ -65,6 +66,6 @@ yum -y install ${MANYLINUX1_DEPS}
 yum -y clean all > /dev/null 2>&1
 yum list installed
 
-for PYTHON in /opt/*/bin/python; do
+for PYTHON in /opt/python/*/bin/python; do
     $PYTHON $MY_DIR/manylinux1-check.py
 done

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -23,55 +23,61 @@ function lex_pyver {
 }
 
 
-function do_python_build {
+function do_cpython_build {
     local py_ver=$1
     check_var $py_ver
-    local soabi_flags=$2
-    check_var $soabi_flags
-    mkdir -p /opt/python/${py_ver}${soabi_flags}/lib
-    if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.3) ]; then
-        if [ $soabi_flags = "mu" ]; then
-            local unicode_flags="--enable-unicode=ucs4"
-        else
-            local unicode_flags="--enable-unicode=ucs2"
-        fi
+    local ucs_setting=$2
+    check_var $ucs_setting
+    tar -xzf Python-$py_ver.tgz
+    pushd Python-$py_ver
+    if [ "$ucs_setting" = "none" ]; then
+        unicode_flags=""
+        dir_suffix=""
+    else
+        local unicode_flags="--enable-unicode=$ucs_setting"
+        local dir_suffix="-$ucs_setting"
     fi
+    local prefix="/opt/_internal/cpython-${py_ver}${dir_suffix}"
+    mkdir -p ${prefix}/lib
     # -Wformat added for https://bugs.python.org/issue17547 on Python 2.6
-    CFLAGS="-Wformat" ./configure --prefix=/opt/python/${py_ver}${soabi_flags} --disable-shared $unicode_flags > /dev/null
+    CFLAGS="-Wformat" ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
+    popd
+    rm -rf Python-$py_ver
+    # Some python's install as bin/python3. Make them available as
+    # bin/python.
+    if [ -e ${prefix}/bin/python3 ]; then
+        ln -s python3 ${prefix}/bin/python
+    fi
+    ${prefix}/bin/python get-pip.py
+    ${prefix}/bin/pip install wheel
+    local abi_tag=$(${prefix}/bin/python -c \
+        "import wheel.pep425tags; print(wheel.pep425tags.get_abi_tag())")
+    ln -s ${prefix} /opt/python/${abi_tag}
 }
 
 
-function build_python {
+function build_cpython {
     local py_ver=$1
     check_var $py_ver
-    local py_ver2="$(echo $py_ver | cut -d. -f 1,2)"
     check_var $PYTHON_DOWNLOAD_URL
     wget -q $PYTHON_DOWNLOAD_URL/$py_ver/Python-$py_ver.tgz
     if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.3) ]; then
-        local soabi_flags_list="mu m"
+        do_cpython_build $py_ver ucs2
+        do_cpython_build $py_ver ucs4
+    else
+        do_cpython_build $py_ver none
     fi
-    for soabi_flags in ${soabi_flags_list:-m}; do
-        tar -xzf Python-$py_ver.tgz
-        (cd Python-$py_ver && do_python_build $py_ver $soabi_flags)
-        if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3) ]; then \
-            ln -s /opt/python/${py_ver}${soabi_flags}/bin/python3 /opt/python/${py_ver}${soabi_flags}/bin/python;
-        fi;
-        ln -s /opt/python/${py_ver}${soabi_flags}/ /opt/${py_ver2}${soabi_flags}
-        /opt/python/${py_ver}${soabi_flags}/bin/python get-pip.py
-        /opt/python/${py_ver}${soabi_flags}/bin/pip install wheel
-        rm -rf Python-$py_ver
-    done
     rm -f Python-$py_ver.tgz
 }
 
 
-function build_pythons {
+function build_cpythons {
     check_var $GET_PIP_URL
     curl -sLO $GET_PIP_URL
     for py_ver in $@; do
-        build_python $py_ver
+        build_cpython $py_ver
     done
     rm get-pip.py
 }

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -52,8 +52,7 @@ function do_cpython_build {
     fi
     ${prefix}/bin/python get-pip.py
     ${prefix}/bin/pip install wheel
-    local abi_tag=$(${prefix}/bin/python -c \
-        "import wheel.pep425tags; print(wheel.pep425tags.get_abi_tag())")
+    local abi_tag=$(${prefix}/bin/python ${MY_DIR}/python-tag-abi-tag.py)
     ln -s ${prefix} /opt/python/${abi_tag}
 }
 

--- a/docker/build_scripts/python-tag-abi-tag.py
+++ b/docker/build_scripts/python-tag-abi-tag.py
@@ -1,0 +1,7 @@
+# Utility script to print the python tag + the abi tag for a Python
+# See PEP 425 for exactly what these are, but an example would be:
+#   cp27-cp27mu
+
+from wheel.pep425tags import get_abbr_impl, get_impl_ver, get_abi_tag
+
+print("{0}{1}-{2}".format(get_abbr_impl(), get_impl_ver(), get_abi_tag()))


### PR DESCRIPTION
[this probably doesn't work yet, but I was getting weird "network is unreachable" errors trying to build the image locally -- remember, the great thing about docker build is that it produces identical results no matter where you run it! -- so pushing up to see where travis breaks]

As we are reminded by #38, CPython is not the only implementation of
Python around. This PR doesn't add support for PyPy or anything else,
but it does rearrange things a bit to make room for them.

User visible changes:
- the full-version-number CPython build directories are moved into
  /opt/_internal to make clear that users shouldn't rely on the details
  of their names. Also, they're called e.g. cpython-2.6.9 now instead of
  just 2.6.9.
- The entries in /opt/python/ are now exactly the ABI tags used by each
  version. So we have e.g. /opt/python/cp27mu which generates wheels
  named like *-py27-cp27mu-manylinux1_*.whl. If you want to build
  your wheel against all CPythons, that's /opt/python/cp*/bin/python.