### PR TITLE
Slim down our Python installs

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -74,6 +74,19 @@ yum -y erase wireless-tools gtk2 libX11 hicolor-icon-theme \
 yum -y install ${MANYLINUX1_DEPS}
 yum -y clean all > /dev/null 2>&1
 yum list installed
+# we don't need libpython*.a, and they're many megabytes
+find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
+# Strip what we can -- and ignore errors, because this just attempts to strip
+# *everything*, including non-ELF files:
+find /opt/_internal -type f -print0 \
+    | xargs -0 -n1 strip --strip-unneeded 2>/dev/null || true
+# We do not need the Python test suites, or indeed the precompiled .pyc and
+# .pyo files. Partially cribbed from:
+#    https://github.com/docker-library/python/blob/master/3.4/slim/Dockerfile
+find /opt/_internal \
+     \( -type d -a -name test -o -name tests \) \
+  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+  -print0 | xargs -0 rm -f
 
 for PYTHON in /opt/python/*/bin/python; do
     $PYTHON $MY_DIR/manylinux1-check.py


### PR DESCRIPTION
```
  # BEFORE
  [root@1301fcc7b9d3 /]# du --si -s /opt/_internal/
  1.1G	/opt/_internal/

  # SHRINK IT DOWN
  [root@1301fcc7b9d3 /]# find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
  [root@1301fcc7b9d3 /]# du --si -s /opt/_internal/
  802M	/opt/_internal/
  [root@1301fcc7b9d3 /]# find /opt/_internal -type f -print0 | xargs -0 -n1 strip --strip-unneeded 2>/dev/null
  [root@1301fcc7b9d3 /]# du --si -s /opt/_internal/
  695M	/opt/_internal/
  [root@1301fcc7b9d3 /]# find /opt/_internal \( -type d -a -name test -o -name tests \) -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -print0 | xargs -0 rm -f

  # AFTER
  [root@1301fcc7b9d3 /]# du --si -s /opt/_internal/
  341M	/opt/_internal/
```

So this makes /opt/_internal ~3.2x smaller, and shrinks the overall
(unpacked) filesystem from 1.8 GB to 1.1 GB.