### PR TITLE
RF: add linux32 command as entrypoint to image

### DIFF
--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -12,3 +12,6 @@ COPY ./build_scripts /build_scripts
 RUN linux32 bash build_scripts/build.sh && rm -r build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+# Run 32-bit uname selection on way into image
+ENTRYPOINT ["linux32"]


### PR DESCRIPTION
Prefixes linux32 command to commands run when doing `docker run img-name
cmd1 cmd2`.

See: https://docs.docker.com/engine/reference/builder/#entrypoint

After this change:

```
$ docker run -ti --rm this_image /bin/bash
bash-3.2# uname -a
Linux a7ea88dd9145 3.10.0-327.13.1.el7.x86_64 #1 SMP Thu Mar 31 16:04:38
UTC 2016 i686 i686 i386 GNU/Linux
```

Note that passing `linux32` prefix explicitly on the command line, as we
have been doing, is still valid (but has no extra effect):

```
$ docker run -ti --rm this_image linux32 /bin/bash
bash-3.2# uname -a
Linux d41003890ca4 3.10.0-327.13.1.el7.x86_64 #1 SMP Thu Mar 31 16:04:38
UTC 2016 i686 i686 i386 GNU/Linux
```