### PR TITLE
Fix python-config: no longer links with libpython.

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -57,6 +57,13 @@ function do_cpython_build {
     # bin/python.
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
+        ln -s python3-config ${prefix}/bin/python-config
+    fi
+    # Remove -lpython from the python-config script.
+    if [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.4) ]; then
+        sed -i "s/'-lpython' *+ *pyver\( *+ *sys.abiflags\)\?/''/" $(readlink -e ${prefix}/bin/python-config)
+    else
+        sed -i 's/-lpython${VERSION}${ABIFLAGS}//' $(readlink -e ${prefix}/bin/python-config)
     fi
     ${prefix}/bin/python get-pip.py
     ${prefix}/bin/pip install wheel


### PR DESCRIPTION
This monkey patches the python-config script so that build scripts that use it don't try to link to libpythonX.X.so, which is absent from the manylinux distribution.  See #69 for more information.

This also adds `python-config` -> `python3-config` symlink to Python 3 installs, analogous to the existing `python` -> `python3` symlink.

Closes: #85