### PR TITLE
Use a modern version of SQLite3

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -54,6 +54,15 @@ yum -y install bzip2 make git patch unzip bison yasm diffutils \
 build_autoconf $AUTOCONF_ROOT $AUTOCONF_HASH
 autoconf --version
 
+# Install a more recent SQLite3
+curl -sO https://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz
+tar xfz sqlite-autoconf-3160200.tar.gz
+cd sqlite-autoconf-3160200
+./configure
+make install
+cd ..
+rm -rf sqlite-autoconf-3160200*
+
 # Compile the latest Python releases.
 # (In order to have a proper SSL module, Python is compiled
 # against a recent openssl [see env vars above], which is linked


### PR DESCRIPTION
This patch has "build.sh" install a recent version of SQLite3 (3.16.2) into /usr/local/lib prior to building all the Pythons.  The motivation is two-fold:

- First, it fixes issue #90, namely that sqlite3 is broken under Python 3.6.

- Second, the version of SQLite3 that comes with Centos5 is *very* old, prior to the signifiant changes of SQLite 3.6.0 which itself was released in mid-2008.  This causes problems when building a Python module that relies on any of these SQLite features, since (a) one can't run the doctests and (b) things like Sphinx's autodoc only work if you can actually import the module.  

I have successfully tested the resulting Docker container by building wheels for [this project](https://bitbucket.org/t3m/snappy). 