### PR TITLE
Update patchelf from latest master to fix #78

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -13,11 +13,13 @@ OPENSSL_ROOT=openssl-1.0.2k
 OPENSSL_HASH=6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
-PATCHELF_HASH=d9afdff4baeacfbc64861454f368b7f2c15c44d245293f7587bbf726bfe722fb
+PATCHELF_VERSION=6bfcafbba8d89e44f9ac9582493b4f27d9d8c369
 CURL_ROOT=curl-7.49.1
 CURL_HASH=eb63cec4bef692eab9db459033f409533e6d10e20942f4b060b32819e81885f1
 AUTOCONF_ROOT=autoconf-2.69
 AUTOCONF_HASH=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+AUTOMAKE_ROOT=automake-1.15
+AUTOMAKE_HASH=7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
 
 # Dependencies for compiling Python that we want to remove from
 # the final image after compiling Python
@@ -64,6 +66,10 @@ yum -y install bzip2 make git patch unzip bison yasm diffutils \
 build_autoconf $AUTOCONF_ROOT $AUTOCONF_HASH
 autoconf --version
 
+# Install newest automake
+build_automake $AUTOMAKE_ROOT $AUTOMAKE_HASH
+automake --version
+
 # Install a more recent SQLite3
 curl -sO https://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz
 tar xfz sqlite-autoconf-3160200.tar.gz
@@ -105,11 +111,10 @@ curl-config --features
 rm -rf /usr/local/ssl
 
 # Install patchelf (latest with unreleased bug fixes)
-curl -sLO https://nipy.bic.berkeley.edu/manylinux/patchelf-0.9njs2.tar.gz
-check_sha256sum patchelf-0.9njs2.tar.gz $PATCHELF_HASH
-tar -xzf patchelf-0.9njs2.tar.gz
-(cd patchelf-0.9njs2 && ./configure && make && make install)
-rm -rf patchelf-0.9njs2.tar.gz patchelf-0.9njs2
+curl -sL -o patchelf.tar.gz https://github.com/NixOS/patchelf/archive/$PATCHELF_VERSION.tar.gz
+tar -xzf patchelf.tar.gz
+(cd patchelf-$PATCHELF_VERSION && ./bootstrap.sh && ./configure && make && make install)
+rm -rf patchelf.tar.gz patchelf-$PATCHELF_VERSION
 
 # Install latest pypi release of auditwheel
 $PY36_BIN/pip install auditwheel

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -12,6 +12,7 @@ CURL_DOWNLOAD_URL=http://curl.askapache.com/download
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 AUTOCONF_DOWNLOAD_URL=http://ftp.gnu.org/gnu/autoconf
+AUTOMAKE_DOWNLOAD_URL=http://ftp.gnu.org/gnu/automake
 
 
 function check_var {
@@ -165,4 +166,17 @@ function build_autoconf {
     tar -zxf ${autoconf_fname}.tar.gz
     (cd ${autoconf_fname} && do_standard_install)
     rm -rf ${autoconf_fname} ${autoconf_fname}.tar.gz
+}
+
+function build_automake {
+    local automake_fname=$1
+    check_var ${automake_fname}
+    local automake_sha256=$2
+    check_var ${automake_sha256}
+    check_var ${AUTOMAKE_DOWNLOAD_URL}
+    curl -sLO ${AUTOMAKE_DOWNLOAD_URL}/${automake_fname}.tar.gz
+    check_sha256sum ${automake_fname}.tar.gz ${automake_sha256}
+    tar -zxf ${automake_fname}.tar.gz
+    (cd ${automake_fname} && do_standard_install)
+    rm -rf ${automake_fname} ${automake_fname}.tar.gz
 }


### PR DESCRIPTION
Builds patchelf directly from latest source (which needs a newer automake). Fixes #78 and https://github.com/spotify/dh-virtualenv/issues/150, https://github.com/spotify/dh-virtualenv/issues/168, and https://github.com/spotify/dh-virtualenv/issues/203 among others.