### PR TITLE
Specify /bin/bash as the default command

### DIFF
--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -15,3 +15,5 @@ ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 
 # Run 32-bit uname selection on way into image
 ENTRYPOINT ["linux32"]
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -12,3 +12,5 @@ COPY build_scripts /build_scripts
 RUN bash build_scripts/build.sh && rm -r build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Saves having to type it in the `docker run` command.

Reference: https://docs.docker.com/engine/reference/builder/#cmd