### PR TITLE
Drop support for Python 2.6.

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -5,7 +5,7 @@
 set -ex
 
 # Python versions to be installed in /opt/$VERSION_NO
-CPYTHON_VERSIONS="2.6.9 2.7.13 3.3.6 3.4.6 3.5.3 3.6.0"
+CPYTHON_VERSIONS="2.7.13 3.3.6 3.4.6 3.5.3 3.6.0"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive


### PR DESCRIPTION
It's broken because pip and setuptools have dropped support, and
no-one seems to be bothered or care about fixing it, so let's do this.

Closes #126