### PR TITLE
Update centos before doing anything else.

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -42,6 +42,15 @@ sed -i 's/#\(baseurl.*\)mirror.centos.org\/centos\/$releasever/\1vault.centos.or
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/build_utils.sh
 
+# https://hub.docker.com/_/centos/
+# "Additionally, images with minor version tags that correspond to install
+# media are also offered. These images DO NOT recieve updates as they are
+# intended to match installation iso contents. If you choose to use these
+# images it is highly recommended that you include RUN yum -y update && yum
+# clean all in your Dockerfile, or otherwise address any potential security
+# concerns."
+yum -y update && yum clean all
+
 # EPEL support
 yum -y install wget curl
 # curl -sLO https://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -49,7 +49,8 @@ source $MY_DIR/build_utils.sh
 # images it is highly recommended that you include RUN yum -y update && yum
 # clean all in your Dockerfile, or otherwise address any potential security
 # concerns."
-yum -y update && yum clean all
+# Decided not to clean at this point: https://github.com/pypa/manylinux/pull/129
+yum -y update
 
 # EPEL support
 yum -y install wget curl


### PR DESCRIPTION
The centos page on Docker Hub recommends updating packages when using minor tags (e.g., 5.11).