### PR TITLE
Remove '-e' flag from docker login

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker login -e noemail -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
+docker login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
 tag="quay.io/pypa/manylinux1_$PLATFORM"
 docker tag ${tag}:${TRAVIS_COMMIT} ${tag}:latest
 docker push ${tag}:latest


### PR DESCRIPTION
This has apparently been dropped, and they decided that breaking
people was cool because they printed a warning for a while and who
uses docker in unattended workflows lol:

    https://github.com/moby/moby/issues/23390

So currently our deploys are broken:

    https://travis-ci.org/pypa/manylinux/builds/318363683

This should fix them.