### PR TITLE
adds latest (2.4.6) libtool to docker images

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -22,6 +22,8 @@ AUTOCONF_ROOT=autoconf-2.69
 AUTOCONF_HASH=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
 AUTOMAKE_ROOT=automake-1.15
 AUTOMAKE_HASH=7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
+LIBTOOL_ROOT=libtool-2.4.6
+LIBTOOL_HASH=e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
 
 # Dependencies for compiling Python that we want to remove from
 # the final image after compiling Python
@@ -82,6 +84,10 @@ autoconf --version
 # Install newest automake
 build_automake $AUTOMAKE_ROOT $AUTOMAKE_HASH
 automake --version
+
+# Install newest libtool
+build_libtool $LIBTOOL_ROOT $LIBTOOL_HASH
+libtool --version
 
 # Install a more recent SQLite3
 curl -sO https://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -13,6 +13,7 @@ GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
 
 AUTOCONF_DOWNLOAD_URL=http://ftp.gnu.org/gnu/autoconf
 AUTOMAKE_DOWNLOAD_URL=http://ftp.gnu.org/gnu/automake
+LIBTOOL_DOWNLOAD_URL=http://ftp.gnu.org/gnu/libtool
 
 
 function check_var {
@@ -181,6 +182,7 @@ function build_autoconf {
     rm -rf ${autoconf_fname} ${autoconf_fname}.tar.gz
 }
 
+
 function build_automake {
     local automake_fname=$1
     check_var ${automake_fname}
@@ -192,4 +194,18 @@ function build_automake {
     tar -zxf ${automake_fname}.tar.gz
     (cd ${automake_fname} && do_standard_install)
     rm -rf ${automake_fname} ${automake_fname}.tar.gz
+}
+
+
+function build_libtool {
+    local libtool_fname=$1
+    check_var ${libtool_fname}
+    local libtool_sha256=$2
+    check_var ${libtool_sha256}
+    check_var ${LIBTOOL_DOWNLOAD_URL}
+    curl -sSLO ${LIBTOOL_DOWNLOAD_URL}/${libtool_fname}.tar.gz
+    check_sha256sum ${libtool_fname}.tar.gz ${libtool_sha256}
+    tar -zxf ${libtool_fname}.tar.gz
+    (cd ${libtool_fname} && do_standard_install)
+    rm -rf ${libtool_fname} ${libtool_fname}.tar.gz
 }


### PR DESCRIPTION
Added latest libtool with the same strategy used to add autoconf and automake.