### PR TITLE
Enable hash-checking mode for pip install

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -116,11 +116,13 @@ build_cpythons $CPYTHON_VERSIONS
 
 PY36_BIN=/opt/python/cp36-cp36m/bin
 
+# Install certifi and auditwheel
+$PY36_BIN/pip install --require-hashes -r $MY_DIR/py36-requirements.txt
+
 # Our openssl doesn't know how to find the system CA trust store
 #   (https://github.com/pypa/manylinux/issues/53)
 # And it's not clear how up-to-date that is anyway
 # So let's just use the same one pip and everyone uses
-$PY36_BIN/pip install certifi
 ln -s $($PY36_BIN/python -c 'import certifi; print(certifi.where())') \
       /opt/_internal/certs.pem
 # If you modify this line you also have to modify the versions in the
@@ -144,8 +146,6 @@ tar -xzf patchelf.tar.gz
 (cd patchelf-$PATCHELF_VERSION && ./bootstrap.sh && ./configure && make && make install)
 rm -rf patchelf.tar.gz patchelf-$PATCHELF_VERSION
 
-# Install latest pypi release of auditwheel
-$PY36_BIN/pip install auditwheel
 ln -s $PY36_BIN/auditwheel /usr/local/bin/auditwheel
 
 # Clean up development headers and other unnecessary stuff for

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -65,7 +65,7 @@ function do_cpython_build {
     fi
     # Since we fall back on a canned copy of get-pip.py, we might not have
     # the latest pip and friends. Upgrade them to make sure.
-    ${prefix}/bin/pip install -U pip wheel setuptools
+    ${prefix}/bin/pip install -U --require-hashes -r ${MY_DIR}/requirements.txt
     local abi_tag=$(${prefix}/bin/python ${MY_DIR}/python-tag-abi-tag.py)
     ln -s ${prefix} /opt/python/${abi_tag}
 }

--- a/docker/build_scripts/py36-requirements.txt
+++ b/docker/build_scripts/py36-requirements.txt
@@ -1,0 +1,16 @@
+# pip requirements for cpython 3.6
+# NOTE: certifi has GPG signatures; could download and verify independently.
+certifi==2017.11.5 \
+    --hash=sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694 \
+    --hash=sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0
+auditwheel==1.8.0 \
+    --hash=sha256:63468bf62d82b27b1635ffe1c3f1c4e54ef67d0a6d38bedccc38ce6965d56db7 \
+    --hash=sha256:829ec26097f6ca9a239ebfb4d3c6dc093742141423268cb7ba1d8b15fb0c20a2
+# this package required for auditwheel
+pyelftools==0.24 \
+    --hash=sha256:e9dd97d685a5b96b88a988dabadb88e5a539b64cd7d7927fac9a7368dc4c459c
+# this package required for auditwheel
+typing==3.6.2 \
+    --hash=sha256:349b1f9c109c84b53ac79ac1d822eaa68fc91d63b321bd9392df15098f746f53 \
+    --hash=sha256:63a8255fe7c6269916baa440eb9b6a67139b0b97a01af632e7bd2842e1e02f15 \
+    --hash=sha256:d514bd84b284dd3e844f0305ac07511f097e325171f6cc4a20878d11ad771849

--- a/docker/build_scripts/requirements.txt
+++ b/docker/build_scripts/requirements.txt
@@ -1,0 +1,11 @@
+# pip requirements for all cpythons
+# NOTE: pip has GPG signatures; could download and verify independently.
+pip==9.0.1 \
+    --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0 \
+    --hash=sha256:09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d
+wheel==0.30.0 \
+    --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64 \
+    --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8
+setuptools==38.2.5 \
+    --hash=sha256:bcf0d4f3e2f7890e658db11e218b8643afffb905a0e2f2a7d5a6a3e949bb87e6 \
+    --hash=sha256:b080f276cc868670540b2c03cee06cc14d2faf9da7bec0f15058d1b402c94507


### PR DESCRIPTION
It might be a good idea to [add hashes](https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode) to packages installed via ```pip```, such as ```certifi``` and ```auditwheel```.

Upside: This should allow a build of ```manylinux``` which uses ```pip``` to detect whether or not packages have been modified against expectations.

Downside: This requires manually updating dependencies (but that might be acceptable in this case, as we do pin down the versions and hashes of many other packages).

This fixes #137.