### PR TITLE
Disable Travis "branch builds" for pyup- branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ dist: trusty
 services:
   - docker
 
+# Don't build the pyup- branches that pyup.io creates; it's redundant
+# with the PR builds that Travis also does.
+branches:
+  except:
+    - /^pyup-/
+
 env:
   global:
     # QUAY_USERNAME and QUAY_PASSWORD for docker image upload


### PR DESCRIPTION
pyup.io works by creating a branch in the main repo, and then creating
a PR from that branch to master. Travis therefore ends up testing
these commits twice: once because they're a PR, and once because
they're on a branch in the main repo.

This should hopefully disable the branch-based testing, so that we end
up with each PR being tested only once.