### PR TITLE
WIP: Emulate the vsyscall page in userspace in the x86_64 Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
+  - make -C docker/vsyscall_emu
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -8,6 +8,9 @@ ENV PATH /opt/rh/devtoolset-2/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/usr/local/lib64:/usr/local/lib
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
+COPY vsyscall_emu/vsyscall_emu.so /usr/local/lib/vsyscall_emu.so
+COPY vsyscall_emu/ld.so.preload /etc/ld.so.preload
+
 COPY build_scripts /build_scripts
 RUN bash build_scripts/build.sh && rm -r build_scripts
 

--- a/docker/vsyscall_emu/.gitignore
+++ b/docker/vsyscall_emu/.gitignore
@@ -1,0 +1,1 @@
+vsyscall_emu.so

--- a/docker/vsyscall_emu/Makefile
+++ b/docker/vsyscall_emu/Makefile
@@ -1,0 +1,13 @@
+ifeq ($(PLATFORM),x86_64)
+  all: vsyscall_emu.so
+else
+  all:
+endif
+
+vsyscall_emu.so: vsyscall_emu.c
+	$(CC) -fPIC -shared -o $@ $< -ldl
+
+clean:
+	$(RM) -f vsyscall_emu.so
+
+.PHONY: clean

--- a/docker/vsyscall_emu/ld.so.preload
+++ b/docker/vsyscall_emu/ld.so.preload
@@ -1,0 +1,1 @@
+/usr/local/lib/vsyscall_emu.so

--- a/docker/vsyscall_emu/vsyscall_emu.c
+++ b/docker/vsyscall_emu/vsyscall_emu.c
@@ -1,0 +1,94 @@
+#define _GNU_SOURCE
+#include <sys/syscall.h>
+#include <dlfcn.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+static struct sigaction next_handler = {
+	.sa_handler = SIG_DFL,
+};
+
+static int (*real_sigaction)(int, const struct sigaction *, struct sigaction *);
+
+int
+sigaction(int signum,
+          const struct sigaction *act,
+          struct sigaction *old_act)
+{
+	if (signum != SIGSEGV) {
+		return real_sigaction(signum, act, old_act);
+	}
+
+	if (old_act) {
+		*old_act = next_handler;
+	}
+	if (act) {
+		next_handler = *act;
+	}
+	return 0;
+}
+
+
+static greg_t VSYS_gettimeofday = 0xffffffffff600000;
+static long
+syscall_gettimeofday(long arg1, long arg2) {
+	return syscall(SYS_gettimeofday, arg1, arg2);
+}
+
+static greg_t VSYS_time = 0xffffffffff600400;
+static long
+syscall_time(long arg1) {
+	return syscall(SYS_time, arg1);
+}
+
+static greg_t VSYS_getcpu = 0xffffffffff600800;
+static long
+syscall_getcpu(long arg1, long arg2, long arg3) {
+	return syscall(SYS_getcpu, arg1, arg2, arg3);
+}
+
+static void
+handler(int sig, siginfo_t *si, void *ctx)
+{
+	greg_t *regs = ((ucontext_t *)ctx)->uc_mcontext.gregs;
+	if (regs[REG_RIP] == VSYS_gettimeofday) {
+		regs[REG_RIP] = (greg_t)(void *)syscall_gettimeofday;
+	} else if (regs[REG_RIP] == VSYS_time) {
+		regs[REG_RIP] = (greg_t)(void *)syscall_time;
+	} else if (regs[REG_RIP] == VSYS_getcpu) {
+		regs[REG_RIP] = (greg_t)(void *)syscall_getcpu;
+	} else if (next_handler.sa_flags & SA_SIGINFO) {
+		next_handler.sa_sigaction(sig, si, ctx);
+	} else if (next_handler.sa_handler != SIG_DFL && next_handler.sa_handler != SIG_IGN) {
+		next_handler.sa_handler(sig);
+	} else {
+		// SIG_IGN is treated as SIG_DFL
+		struct sigaction sa = {
+			.sa_handler = SIG_DFL,
+		};
+		real_sigaction(sig, &sa, NULL);
+	}
+}
+
+__attribute__((constructor))
+static void
+init(void)
+{
+	real_sigaction = dlsym(RTLD_NEXT, "sigaction");
+	if (!real_sigaction) {
+		fprintf(stderr, "dlsym(\"sigaction\"): %s", dlerror());
+		abort();
+	}
+
+	struct sigaction sa = {
+		.sa_sigaction = handler,
+		.sa_flags = SA_RESTART | SA_SIGINFO,
+	};
+	if (real_sigaction(SIGSEGV, &sa, NULL) != 0) {
+		perror("sigaction");
+		abort();
+	}
+}

--- a/docker/vsyscall_emu/vsyscall_emu.c
+++ b/docker/vsyscall_emu/vsyscall_emu.c
@@ -36,6 +36,20 @@ sigaction(int signum,
 	return 0;
 }
 
+sighandler_t
+signal(int signum, sighandler_t handler)
+{
+	struct sigaction sa = {
+		.sa_handler = handler,
+		.sa_flags = SA_RESETHAND | SA_NODEFER,
+	}, oldsa;
+	if (sigaction(signum, &sa, &oldsa) == 0) {
+		return oldsa.sa_handler;
+	} else {
+		return SIG_ERR;
+	}
+}
+
 int
 sigprocmask (int how, const sigset_t *newset, sigset_t *oldset)
 {

--- a/docker/vsyscall_emu/vsyscall_emu.c
+++ b/docker/vsyscall_emu/vsyscall_emu.c
@@ -1,10 +1,7 @@
 #define _GNU_SOURCE
 #include <sys/syscall.h>
 #include <dlfcn.h>
-#include <errno.h>
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <ucontext.h>
 #include <unistd.h>
 
@@ -122,26 +119,20 @@ init(void)
 {
 	real_sigaction = dlsym(RTLD_NEXT, "sigaction");
 	if (!real_sigaction) {
-		fprintf(stderr, "dlsym(\"sigaction\"): %s", dlerror());
-		abort();
+		return;
 	}
 
 	real_sigprocmask = dlsym(RTLD_NEXT, "sigprocmask");
 	if (!real_sigprocmask) {
-		fprintf(stderr, "dlsym(\"sigprocmask\"): %s", dlerror());
-		abort();
+		return;
 	}
 	if (real_sigprocmask(SIG_BLOCK, NULL, &visible_oldset) == -1) {
-		perror("sigprocmask");
-		abort();
+		return;
 	}
 
 	struct sigaction sa = {
 		.sa_sigaction = handler,
 		.sa_flags = SA_RESTART | SA_SIGINFO,
 	};
-	if (real_sigaction(SIGSEGV, &sa, NULL) != 0) {
-		perror("sigaction");
-		abort();
-	}
+	real_sigaction(SIGSEGV, &sa, NULL);
 }


### PR DESCRIPTION
This is an LD_PRELOAD to catch segfaults from a kernel booted with `vsyscall=none` and turn them into normal syscalls. It works well enough to run bash from wheezy, but I'm not sure how well it works in general and it is probably extremely buggy in the general case. I'm mostly posting it here to run Travis against the Dockerfile and for @markrwilliams' feedback / testing. :) I'll update this comment once it's close to ready for merge.