### PR TITLE
docker/build_script: Update openssl to latest version: 1.0.2n -> 1.0.2o

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 
 script:
   # Workaround Travis issue #9391 (see build_scripts/build_utils.sh - function build_openssl)
-  - (cd docker/build_scripts/ && curl -fsSLO https://www.openssl.org/source/openssl-1.0.2o.tar.gz)
+  - curl -fsS -o docker/openssl-1.0.2o.tar.gz https://www.openssl.org/source/openssl-1.0.2o.tar.gz
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
+  # Workaround Travis issue #9391 (see build_scripts/build_utils.sh - function build_openssl)
+  - (cd docker/build_scripts/ && curl -fsSLO https://www.openssl.org/source/openssl-1.0.2o.tar.gz)
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -9,10 +9,10 @@ CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
-OPENSSL_ROOT=openssl-1.0.2n
-# Hash from https://www.openssl.org/source/openssl-1.0.2n.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/99b8ea3594d1f1f78b0fff1fd8ca7d782aa07e13/Formula/openssl.rb#L11
-OPENSSL_HASH=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
+OPENSSL_ROOT=openssl-1.0.2o
+# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
+# Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11
+OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
 # Update to slightly newer, verified Git commit:

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -8,7 +8,9 @@ set -ex
 CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
-# archive
+# archive.
+# XXX Until travis issue #9391 is addressed. Make sure to update the version in .travis.yml.
+#     See also function build_openssl in build_utils.sh
 OPENSSL_ROOT=openssl-1.0.2o
 # Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
 # Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -135,13 +135,17 @@ function build_openssl {
     local openssl_sha256=$2
     check_var ${openssl_sha256}
     check_var ${OPENSSL_DOWNLOAD_URL}
-    # Can't use curl here because we don't have it yet
-    # Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
-    wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz ||
-      (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
-        (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
-          (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
-            (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz)
+    #
+    # XXX Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
+    #     by downloading the archive outside of the container using https. See .travis.yml
+    #
+    if [ -f ${MY_DIR}/${openssl_fname}.tar.gz ]; then
+        cp ${MY_DIR}/${openssl_fname}.tar.gz .
+    fi
+    if [ ! -f ${MY_DIR}/${openssl_fname}.tar.gz ]; then
+        # Can't use curl here because we don't have it yet
+        wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
+    fi
 
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -136,7 +136,7 @@ function build_openssl {
     check_var ${openssl_sha256}
     check_var ${OPENSSL_DOWNLOAD_URL}
     # Can't use curl here because we don't have it yet
-    wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
+    wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz
     (cd ${openssl_fname} && do_openssl_build)

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -136,7 +136,11 @@ function build_openssl {
     check_var ${openssl_sha256}
     check_var ${OPENSSL_DOWNLOAD_URL}
     # Can't use curl here because we don't have it yet
-    wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
+    # Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
+    wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz || \
+      (sleep 30 && wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) || \
+        (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz)
+
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz
     (cd ${openssl_fname} && do_openssl_build)

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -139,14 +139,9 @@ function build_openssl {
     # XXX Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
     #     by downloading the archive outside of the container using https. See .travis.yml
     #
-    if [ -f ${MY_DIR}/${openssl_fname}.tar.gz ]; then
-        cp ${MY_DIR}/${openssl_fname}.tar.gz .
-    fi
-    if [ ! -f ${MY_DIR}/${openssl_fname}.tar.gz ]; then
-        # Can't use curl here because we don't have it yet
-        wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
-    fi
-
+    [ -f ${MY_DIR}/${openssl_fname}.tar.gz ] && cp ${MY_DIR}/${openssl_fname}.tar.gz .
+    # Can't use curl here because we don't have it yet
+    [ -f ${openssl_fname}.tar.gz ] || wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz
     (cd ${openssl_fname} && do_openssl_build)

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -137,9 +137,11 @@ function build_openssl {
     check_var ${OPENSSL_DOWNLOAD_URL}
     # Can't use curl here because we don't have it yet
     # Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
-    wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz || \
-      (sleep 30 && wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) || \
-        (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz)
+    wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz ||
+      (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
+        (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
+          (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz) ||
+            (sleep 30 && wget ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz)
 
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz


### PR DESCRIPTION
See https://www.openssl.org/news/secadv/20180327.txt (thanks @natefoo for the link)