### PR TITLE
Update OpenSSL to 1.0.2o

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -9,10 +9,10 @@ CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
-OPENSSL_ROOT=openssl-1.0.2n
-# Hash from https://www.openssl.org/source/openssl-1.0.2n.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/99b8ea3594d1f1f78b0fff1fd8ca7d782aa07e13/Formula/openssl.rb#L11
-OPENSSL_HASH=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
+OPENSSL_ROOT=openssl-1.0.2o
+# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
+# Matches hash at https://github.com/Homebrew/homebrew-core/blob/0141aa62b0a8d9043ec6d6a5b0890b7908924f79/Formula/openssl.rb#L11
+OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
 # Update to slightly newer, verified Git commit:


### PR DESCRIPTION
There's a new [security advisory](https://www.openssl.org/news/secadv/20180327.txt) and the 1.0.2n images have been removed from the FTP directory.