### PR TITLE
Prefetch source tarballs for OpenSSL and curl outside the docker build context in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,4 @@ docs/_build/
 target/
 
 # Prefetched source
-docker/sources/*
-!docker/sources/.empty
+docker/sources

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Prefetched source
+docker/sources/*
+!docker/sources/.empty

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
-  # Workaround Travis issue #9391 (see build_scripts/build_utils.sh - function build_openssl)
-  - curl -fsS -o docker/build_scripts/openssl-1.0.2o.tar.gz https://www.openssl.org/source/openssl-1.0.2o.tar.gz
+  - bash ./docker/build_scripts/prefetch.sh docker/sources openssl curl
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
+  # Workaround Travis issue #9391 (see build_scripts/build_utils.sh - function build_openssl)
+  - curl -fsS -o docker/build_scripts/openssl-1.0.2o.tar.gz https://www.openssl.org/source/openssl-1.0.2o.tar.gz
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - env: PLATFORM="x86_64"
 
 script:
-  - bash ./docker/build_scripts/prefetch.sh docker/sources openssl curl
+  - bash ./docker/build_scripts/prefetch.sh openssl curl
   - docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
 
 

--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -8,7 +8,8 @@ ENV PATH /opt/rh/devtoolset-2/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/usr/local/lib64:/usr/local/lib
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-COPY ./build_scripts /build_scripts
+COPY build_scripts /build_scripts
+COPY sources /
 RUN linux32 bash build_scripts/build.sh && rm -r build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -9,6 +9,7 @@ ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/roo
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 COPY build_scripts /build_scripts
+COPY sources /
 RUN bash build_scripts/build.sh && rm -r build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -1,0 +1,16 @@
+Building Docker images
+======================
+
+Due to the age of CentOS 5, its version of ``wget`` is unable to fetch
+OpenSSL and curl source tarballs. Modern versions of these are needed in
+order to fetch the remaining sources.
+
+To build the Docker images, you will need to fetch the tarballs to
+``docker/sources/`` prior to building. This can be done with the
+provided prefetch script, after which you can proceed with building:
+
+```console
+$ bash docker/build_utils/prefetch.sh openssl curl
+$ docker build --rm -t example/manylinux1_i686 -f docker/Dockerfile-i686 docker/
+$ docker build --rm -t example/manylinux1_x86_64 -f docker/Dockerfile-x86_64 docker/
+```

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -9,10 +9,10 @@ CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
-OPENSSL_ROOT=openssl-1.0.2n
-# Hash from https://www.openssl.org/source/openssl-1.0.2n.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/99b8ea3594d1f1f78b0fff1fd8ca7d782aa07e13/Formula/openssl.rb#L11
-OPENSSL_HASH=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
+OPENSSL_ROOT=openssl-1.0.2o
+# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
+# Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11
+OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
 # Update to slightly newer, verified Git commit:

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -4,36 +4,9 @@
 # Stop at any error, show all commands
 set -ex
 
-# Python versions to be installed in /opt/$VERSION_NO
-CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
-
-# openssl version to build, with expected sha256 hash of .tar.gz
-# archive.
-# XXX Until travis issue #9391 is addressed. Make sure to update the version in .travis.yml.
-#     See also function build_openssl in build_utils.sh
-OPENSSL_ROOT=openssl-1.0.2o
-# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11
-OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
-EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
-DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
-# Update to slightly newer, verified Git commit:
-# https://github.com/NixOS/patchelf/commit/2a9cefd7d637d160d12dc7946393778fa8abbc58
-PATCHELF_VERSION=2a9cefd7d637d160d12dc7946393778fa8abbc58
-PATCHELF_HASH=12da4727f09be42ae0b54878e1b8e86d85cb7a5b595731cdc1a0a170c4873c6d
-CURL_ROOT=curl_7.52.1
-CURL_HASH=a8984e8b20880b621f61a62d95ff3c0763a3152093a9f9ce4287cfd614add6ae
-AUTOCONF_ROOT=autoconf-2.69
-AUTOCONF_HASH=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
-AUTOMAKE_ROOT=automake-1.15
-AUTOMAKE_HASH=7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
-LIBTOOL_ROOT=libtool-2.4.6
-LIBTOOL_HASH=e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
-SQLITE_AUTOCONF_VERSION=sqlite-autoconf-3210000
-# Homebrew saw the same hash: https://github.com/Homebrew/homebrew-core/blob/e3a8622111ecefe444194cade5cca3c69165e26c/Formula/sqlite.rb#L6
-SQLITE_AUTOCONF_HASH=d7dd516775005ad87a57f428b6f86afd206cb341722927f104d3f0cf65fbbbe3
-GIT_ROOT=2.16.2
-GIT_HASH=cbdc2398204c7b7bed64f28265870aabe40dd3cd5c0455f7d315570ad7f7f5c8
+# Set build environment variables
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+. $MY_DIR/build_env.sh
 
 # Dependencies for compiling Python that we want to remove from
 # the final image after compiling Python
@@ -53,7 +26,6 @@ sed -i 's/mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo
 sed -i 's/#\(baseurl.*\)mirror.centos.org\/centos\/$releasever/\1vault.centos.org\/5.11/' /etc/yum.repos.d/*.repo
 
 # Get build utilities
-MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/build_utils.sh
 
 # https://hub.docker.com/_/centos/

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -8,7 +8,9 @@ set -ex
 CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
-# archive
+# archive.
+# XXX Until travis issue #9391 is addressed. Make sure to update the version in .travis.yml.
+#     See also function build_openssl in build_utils.sh
 OPENSSL_ROOT=openssl-1.0.2o
 # Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
 # Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11

--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -1,0 +1,47 @@
+# source me
+
+PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
+CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
+
+# openssl version to build, with expected sha256 hash of .tar.gz
+# archive.
+OPENSSL_ROOT=openssl-1.0.2o
+OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+# XXX: the official https server at www.openssl.org cannot be reached
+# with the old versions of openssl and curl in Centos 5.11 hence this is
+# overridden in build_utils.sh to the ftp mirror:
+OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
+
+# Update to slightly newer, verified Git commit:
+# https://github.com/NixOS/patchelf/commit/2a9cefd7d637d160d12dc7946393778fa8abbc58
+PATCHELF_VERSION=2a9cefd7d637d160d12dc7946393778fa8abbc58
+PATCHELF_HASH=12da4727f09be42ae0b54878e1b8e86d85cb7a5b595731cdc1a0a170c4873c6d
+
+CURL_ROOT=curl_7.52.1
+CURL_HASH=a8984e8b20880b621f61a62d95ff3c0763a3152093a9f9ce4287cfd614add6ae
+# We had to switch to a debian mirror because we can't use TLS until we
+# bootstrap it with this curl + openssl
+CURL_DOWNLOAD_URL=http://deb.debian.org/debian/pool/main/c/curl
+CURL_EXTENSION=.orig.tar.gz
+
+AUTOCONF_ROOT=autoconf-2.69
+AUTOCONF_HASH=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
+AUTOCONF_DOWNLOAD_URL=http://ftp.gnu.org/gnu/autoconf
+AUTOMAKE_ROOT=automake-1.15
+AUTOMAKE_HASH=7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
+AUTOMAKE_DOWNLOAD_URL=http://ftp.gnu.org/gnu/automake
+LIBTOOL_ROOT=libtool-2.4.6
+LIBTOOL_HASH=e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
+LIBTOOL_DOWNLOAD_URL=http://ftp.gnu.org/gnu/libtool
+
+SQLITE_AUTOCONF_VERSION=sqlite-autoconf-3210000
+# Homebrew saw the same hash: https://github.com/Homebrew/homebrew-core/blob/e3a8622111ecefe444194cade5cca3c69165e26c/Formula/sqlite.rb#L6
+SQLITE_AUTOCONF_HASH=d7dd516775005ad87a57f428b6f86afd206cb341722927f104d3f0cf65fbbbe3
+
+GIT_ROOT=2.16.2
+GIT_HASH=cbdc2398204c7b7bed64f28265870aabe40dd3cd5c0455f7d315570ad7f7f5c8
+GIT_DOWNLOAD_URL=https://github.com/git/git/archive
+
+GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
+DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc

--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -7,9 +7,6 @@ CPYTHON_VERSIONS="2.7.14 3.3.7 3.4.7 3.5.4 3.6.4"
 # archive.
 OPENSSL_ROOT=openssl-1.0.2o
 OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
-# XXX: the official https server at www.openssl.org cannot be reached
-# with the old versions of openssl and curl in Centos 5.11 hence this is
-# overridden in build_utils.sh to the ftp mirror:
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
 # Update to slightly newer, verified Git commit:
@@ -17,12 +14,9 @@ OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 PATCHELF_VERSION=2a9cefd7d637d160d12dc7946393778fa8abbc58
 PATCHELF_HASH=12da4727f09be42ae0b54878e1b8e86d85cb7a5b595731cdc1a0a170c4873c6d
 
-CURL_ROOT=curl_7.52.1
-CURL_HASH=a8984e8b20880b621f61a62d95ff3c0763a3152093a9f9ce4287cfd614add6ae
-# We had to switch to a debian mirror because we can't use TLS until we
-# bootstrap it with this curl + openssl
-CURL_DOWNLOAD_URL=http://deb.debian.org/debian/pool/main/c/curl
-CURL_EXTENSION=.orig.tar.gz
+CURL_ROOT=curl-7.59.0
+CURL_HASH=099d9c32dc7b8958ca592597c9fabccdf4c08cfb7c114ff1afbbc4c6f13c9e9e
+CURL_DOWNLOAD_URL=https://curl.haxx.se/download
 
 AUTOCONF_ROOT=autoconf-2.69
 AUTOCONF_HASH=954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -135,8 +135,13 @@ function build_openssl {
     local openssl_sha256=$2
     check_var ${openssl_sha256}
     check_var ${OPENSSL_DOWNLOAD_URL}
+    #
+    # XXX Workaround Travis issue #9391 (FTP connections on GCE (a.k.a. `sudo`-required) infrastructure are unreliable)
+    #     by downloading the archive outside of the container using https. See .travis.yml
+    #
+    [ -f ${MY_DIR}/${openssl_fname}.tar.gz ] && cp ${MY_DIR}/${openssl_fname}.tar.gz .
     # Can't use curl here because we don't have it yet
-    wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
+    [ -f ${openssl_fname}.tar.gz ] || wget -q ${OPENSSL_DOWNLOAD_URL}/${openssl_fname}.tar.gz
     check_sha256sum ${openssl_fname}.tar.gz ${openssl_sha256}
     tar -xzf ${openssl_fname}.tar.gz
     (cd ${openssl_fname} && do_openssl_build)

--- a/docker/build_scripts/prefetch.sh
+++ b/docker/build_scripts/prefetch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Prefetch tarballs so they don't need to be fetched in the container (which has
+# very old tools)
+#
+# usage: prefetch.sh <output_dir> [name ...]
+set -ex
+
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+. $MY_DIR/build_env.sh
+. $MY_DIR/build_utils.sh
+
+dir=$1
+check_var ${dir}
+shift
+
+[ -d "$dir" ] || mkdir "$dir"
+
+for name in "$@"; do
+    name=$(echo $name | tr '[:lower:]' '[:upper:]')
+    root=${name}_ROOT
+    ext=${name}_EXTENSION
+    url=${name}_DOWNLOAD_URL
+    file=${!root}${!ext:-.tar.gz}
+    fetch_source $file ${!url} $dir
+done

--- a/docker/build_scripts/prefetch.sh
+++ b/docker/build_scripts/prefetch.sh
@@ -1,25 +1,23 @@
 #!/bin/bash
 # Prefetch tarballs so they don't need to be fetched in the container (which has
-# very old tools)
+# very old tools). Requires Bash 4.0+, but this is not run inside the build context.
 #
 # usage: prefetch.sh <output_dir> [name ...]
 set -ex
+
+SOURCES=docker/sources
 
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 . $MY_DIR/build_env.sh
 . $MY_DIR/build_utils.sh
 
-dir=$1
-check_var ${dir}
-shift
-
-[ -d "$dir" ] || mkdir "$dir"
+[ -d "$SOURCES" ] || mkdir "$SOURCES"
+cd "$SOURCES"
 
 for name in "$@"; do
-    name=$(echo $name | tr '[:lower:]' '[:upper:]')
-    root=${name}_ROOT
-    ext=${name}_EXTENSION
-    url=${name}_DOWNLOAD_URL
+    root=${name^^}_ROOT
+    ext=${name^^}_EXTENSION
+    url=${name^^}_DOWNLOAD_URL
     file=${!root}${!ext:-.tar.gz}
-    fetch_source $file ${!url} $dir
+    fetch_source $file ${!url}
 done

--- a/docker/sources/.empty
+++ b/docker/sources/.empty
@@ -1,0 +1,2 @@
+This directory exists for prefetching source tarballs with Travis (but to avoid failing `COPY` in the Dockerfile if
+prefetching isn't used).

--- a/docker/sources/.empty
+++ b/docker/sources/.empty
@@ -1,2 +1,0 @@
-This directory exists for prefetching source tarballs with Travis (but to avoid failing `COPY` in the Dockerfile if
-prefetching isn't used).


### PR DESCRIPTION
Also, upgrade OpenSSL to 1.0.2o.

This should avoid problems with using the old tools (e.g. wget) in EL5 to fetch these sources. Since people may do Docker Hub, quay.io, etc. automated builds of their own forks from the Dockerfile/context only, prefetching is not required and if sources are not prefetched we fall back to in-container fetching.

There's a lot more work that can be done to reduce duplication in the build scripts, especially with bash indirect references.

Incorporates/supercedes #172, xref #170, thanks @jcfr