### PR TITLE
Only run deploy script from pypa/manylinux repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ deploy:
   script: docker/deploy.sh
   on:
     branch: master
+    repo: pypa/manylinux


### PR DESCRIPTION
This prevents the deploy script to be ran on forks of pypa/manylinux when travis-ci is enabled on those forks.
The deploy script not only fails on forks, it takes up 2x10 minutes  (default timeout) build time on travis-ci infrastructure.