### PR TITLE
Remove wget utility

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -54,6 +54,9 @@ mv devtools-2.repo /etc/yum.repos.d/devtools-2.repo
 rpm -Uvh --replacepkgs epel-release-5*.rpm
 rm -f epel-release-5*.rpm
 
+# from now on, we shall only use curl to retrieve files
+yum -y erase wget
+
 # Development tools and libraries
 yum -y install \
     automake \


### PR DESCRIPTION
The system provided wget utility shall not be used, it's still using the system provided OpenSSL which is too old for most secure downloads (no TLS v1.1/v1.2 support).