### PR TITLE
Remove Bash 4.0+ requirement to run prefetch.sh

### DIFF
--- a/docker/build_scripts/prefetch.sh
+++ b/docker/build_scripts/prefetch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Prefetch tarballs so they don't need to be fetched in the container (which has
-# very old tools). Requires Bash 4.0+, but this is not run inside the build context.
+# very old tools).
 #
 # usage: prefetch.sh <output_dir> [name ...]
 set -ex
@@ -15,9 +15,10 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "$SOURCES"
 
 for name in "$@"; do
-    root=${name^^}_ROOT
-    ext=${name^^}_EXTENSION
-    url=${name^^}_DOWNLOAD_URL
+    name_upper=$(echo "${name}" | tr [:lower:] [:upper:])
+    root=${name_upper}_ROOT
+    ext=${name_upper}_EXTENSION
+    url=${name_upper}_DOWNLOAD_URL
     file=${!root}${!ext:-.tar.gz}
     fetch_source $file ${!url}
 done


### PR DESCRIPTION
This allows to run the build script from a host that provides bash 3.x (e.g. macOS)