### PR TITLE
Reduce image size

### DIFF
--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -1,4 +1,4 @@
-FROM centos:5.11
+FROM centos:5
 MAINTAINER The ManyLinux project
 
 ENV LC_ALL en_US.UTF-8

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -170,10 +170,9 @@ find /opt/_internal -type f -print0 \
 # We do not need the Python test suites, or indeed the precompiled .pyc and
 # .pyo files. Partially cribbed from:
 #    https://github.com/docker-library/python/blob/master/3.4/slim/Dockerfile
-find /opt/_internal \
+find /opt/_internal -depth \
      \( -type d -a -name test -o -name tests \) \
-  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-  -print0 | xargs -0 rm -f
+  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) | xargs rm -rf
 
 for PYTHON in /opt/python/*/bin/python; do
     # Smoke test to make sure that our Pythons work, and do indeed detect as


### PR DESCRIPTION
1st commit fixes python test removal: around 100MB saved
2nd commit makes x86_64 image based on `centos:5` rather than `centos:5.11`: around 150MB saved
