### PR TITLE
[WIP] Reduce image size

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -11,7 +11,7 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 # Dependencies for compiling Python that we want to remove from
 # the final image after compiling Python
 # GPG installed to verify signatures on Python source tarballs.
-PYTHON_COMPILE_DEPS="zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel gpg libffi-devel"
+PYTHON_COMPILE_DEPS="expat-devel gettext tcl-devel libtermcap-devel zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel gpg libffi-devel"
 
 # Libraries that are allowed as part of the manylinux1 profile
 MANYLINUX1_DEPS="glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel  mesa-libGL-devel libICE-devel libSM-devel ncurses-devel"
@@ -68,8 +68,6 @@ yum -y install \
     devtoolset-2-gcc-c++ \
     devtoolset-2-gcc-gfortran \
     diffutils \
-    expat-devel \
-    gettext \
     kernel-devel-`uname -r` \
     file \
     make \

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -168,13 +168,6 @@ find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
 find /opt/_internal -type f -print0 \
     | xargs -0 -n1 strip --strip-unneeded 2>/dev/null || true
 
-# We do not need the Python test suites, or indeed the precompiled .pyc and
-# .pyo files. Partially cribbed from:
-#    https://github.com/docker-library/python/blob/master/3.4/slim/Dockerfile
-find /opt/_internal -depth \
-     \( -type d -a -name test -o -name tests \) \
-  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) | xargs rm -rf
-
 for PYTHON in /opt/python/*/bin/python; do
     # Smoke test to make sure that our Pythons work, and do indeed detect as
     # being manylinux compatible:
@@ -182,6 +175,13 @@ for PYTHON in /opt/python/*/bin/python; do
     # Make sure that SSL cert checking works
     $PYTHON $MY_DIR/ssl-check.py
 done
+
+# We do not need the Python test suites, or indeed the precompiled .pyc and
+# .pyo files. Partially cribbed from:
+#    https://github.com/docker-library/python/blob/master/3.4/slim/Dockerfile
+find /opt/_internal -depth \
+     \( -type d -a -name test -o -name tests \) \
+  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) | xargs rm -rf
 
 # Fix libc headers to remain compatible with C99 compilers.
 find /usr/include/ -type f -exec sed -i 's/\bextern _*inline_*\b/extern __inline __attribute__ ((__gnu_inline__))/g' {} +

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -104,9 +104,10 @@ function build_cpythons {
 
 
 function do_openssl_build {
-    ./config no-ssl2 no-shared -fPIC --prefix=/usr/local/ssl > /dev/null
+    ./config no-ssl2 shared --prefix=/opt/_internal/_vendor --openssldir=/opt/_internal/_vendor > /dev/null
     make > /dev/null
     make install_sw > /dev/null
+    rm -rf /opt/_internal/_vendor/bin /opt/_internal/_vendor/lib/*.a
 }
 
 
@@ -170,15 +171,13 @@ function build_git {
     fetch_source v${git_fname}.tar.gz ${GIT_DOWNLOAD_URL}
     check_sha256sum v${git_fname}.tar.gz ${git_sha256}
     tar -xzf v${git_fname}.tar.gz
-    (cd git-${git_fname} && make install prefix=/usr/local LDFLAGS="-L/usr/local/ssl/lib -ldl" CFLAGS="-I/usr/local/ssl/include" > /dev/null)
+    (cd git-${git_fname} && make install prefix=/usr/local NO_GETTEXT=1 LDFLAGS="-L/opt/_internal/_vendor/lib -ldl" CFLAGS="-I/opt/_internal/_vendor/include" > /dev/null)
     rm -rf git-${git_fname} v${git_fname}.tar.gz
 }
 
 
 function do_curl_build {
-    # We do this shared to avoid obnoxious linker issues where git couldn't
-    # link properly. If anyone wants to make this build statically go for it.
-    LIBS=-ldl CFLAGS=-Wl,--exclude-libs,ALL ./configure --with-ssl --disable-static > /dev/null
+    LD_LIBRARY_PATH=/opt/_internal/_vendor/lib:$LD_LIBRARY_PATH LIBS=-ldl CFLAGS=-Wl,--exclude-libs,ALL ./configure --with-ssl=/opt/_internal/_vendor --disable-static --prefix=/opt/_internal/_vendor --bindir=/usr/local/bin > /dev/null
     make > /dev/null
     make install > /dev/null
 }


### PR DESCRIPTION
1st & 2nd commits provide a small improvement and are quite straightforward.
The 3rd commit allows around 60MB to be saved. It uses a shared library of OpenSSL rather than the static version. OpenSSL & curl shared libraries are isolated from system ones using patchelf to change soname and dependencies (as does auditwheel for manylinux wheels).
Overall, 74MB saved.
