### PR TITLE
Update build_utils.sh to leave python headers in place

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -44,7 +44,7 @@ function do_cpython_build {
     fi
     local prefix="/opt/_internal/cpython-${py_ver}${dir_suffix}"
     mkdir -p ${prefix}/lib
-    ./configure --prefix=${prefix} --disable-shared $unicode_flags > /dev/null
+    ./configure --prefix=${prefix} --enable-shared $unicode_flags > /dev/null
     make -j2 > /dev/null
     make install > /dev/null
     popd


### PR DESCRIPTION
I'm building python extensions which rely on boost-python.... boost python has to be built against python headers.... using --enable-shared at python build-time leaves the necessary python headers in place for each python release....