### PR TITLE
Fix error when old curl tarball is in directory

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -194,7 +194,7 @@ function build_curl {
     check_required_source ${curl_fname}.tar.gz
     check_sha256sum ${curl_fname}.tar.gz ${curl_sha256}
     tar -zxf ${curl_fname}.tar.gz
-    (cd curl-* && do_curl_build)
+    (cd curl-*/ && do_curl_build)
     rm -rf curl-*
 }
 


### PR DESCRIPTION
This is just a one-letter change that prevents errors like this one from occurring when an older cURL tarball is still in the directory (eg. when building manylinux incrementally in combination with `prefetch.sh`):
```
+ rm -f curl-7.61.1.tar.gz.sha256
+ tar -zxf curl-7.61.1.tar.gz
+ cd curl-7.60.0.tar.gz curl-7.61.1 curl-7.61.1.tar.gz
build_scripts/build_utils.sh: line 197: cd: curl-7.60.0.tar.gz: Not a directory
```
The issue occurs because `cd curl-*` tries to cd into the tarball.  The trailing slash prevents this by only matching the directory.