### PR TITLE
Do not call docker system prune

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,3 @@ set -ex
 
 docker/build_scripts/prefetch.sh openssl curl
 docker build --rm -t quay.io/pypa/manylinux1_$PLATFORM:$TRAVIS_COMMIT -f docker/Dockerfile-$PLATFORM docker/
-docker system prune -f


### PR DESCRIPTION
This allows not to interfere on local system when testing and has no impact on travis-ci build