### PR TITLE
Add an AUDITWHEEL_PLAT environment variable

### DIFF
--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -1,6 +1,7 @@
 FROM phusion/centos-5-32
 MAINTAINER The ManyLinux project
 
+ENV AUDITWHEEL_PLAT manylinux1_i686
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -1,6 +1,7 @@
 FROM centos:5
 MAINTAINER The ManyLinux project
 
+ENV AUDITWHEEL_PLAT manylinux1_x86_64
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
The idea is that this environment variable could be used as a default value to the --plat argument of auditwheel repair command