### PR TITLE
Reduce image size

### DIFF
--- a/docker/glibc/Dockerfile
+++ b/docker/glibc/Dockerfile
@@ -6,7 +6,18 @@ RUN bash /build_scripts/rebuild-glibc-without-vsyscall.sh
 FROM centos:6
 LABEL maintainer="The Manylinux project"
 
-COPY --from=centos-with-vsyscall /rpms /rpms
+# do not install debuginfo
+COPY --from=centos-with-vsyscall \
+    /rpms/glibc-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-common-2.12-1.212.1.el6.x86_64.rpm \
+    #/rpms/glibc-debuginfo-2.12-1.212.1.el6.x86_64.rpm \
+    #/rpms/glibc-debuginfo-common-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-devel-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-headers-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-static-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-utils-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/nscd-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/
 
 RUN yum -y install /rpms/* && rm -rf /rpms && yum -y clean all && rm -rf /var/cache/yum/* && \
     # if we updated glibc, we need to strip locales again...


### PR DESCRIPTION
Do not install glibc debuginfo packages.
This saves around 150MB in the image.