### PR TITLE
Add Python-3.8.0b1

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -1,7 +1,7 @@
 # source me
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
-CPYTHON_VERSIONS="2.7.16 3.4.10 3.5.7 3.6.8 3.7.3"
+CPYTHON_VERSIONS="2.7.16 3.4.10 3.5.7 3.6.8 3.7.3 3.8.0b1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.


### PR DESCRIPTION
It would make sense to add the beta before the release lands, so that package maintainers have time to adjust their pipelines and build wheels for 3.8.