### PR TITLE
Remove left over libxcrypt files

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -255,6 +255,7 @@ function build_libxcrypt {
         do_standard_install \
         --disable-obsolete-api \
         --enable-hashes=all)
+    rm -rf "v$LIBXCRYPT_VERSION" "libxcrypt-$LIBXCRYPT_VERSION"
 
     # Delete GLIBC version headers and libraries
     rm -rf /usr/include/crypt.h


### PR DESCRIPTION
The tarball and the uncompressed directory was not being removed in the
build script.

Resolves: #328 