### PR TITLE
Add manylinux2010-i686 docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,22 @@ env:
     - secure: "lKaTzEL6UNiEfp+BWLOUILG9BMtjwEMpwt6Yag0cQGHix7qJ/ElZ0t3oFw6ZwuDmA5qceAXIdxHLUK9HGVI2MloLk8czGhjvtfJ4XhOxtEJRQ0VkDGPsKN4cfhB4ZjGo6GAPtNqStMyNiY7BZuTrZa7coDLCoUeYcOmTpi6pmd1rrkk725B9QCTuhFHbPhkuL2yu/Jk6WxkHJBKjmuZek+iQa7lRItgMrG0/319PXLvwIGGl00nLFy+Ly5Ciwzux4wuHLTySZQKu0H9FX81A7smM0FW/42kg3ckGa2qLxRw/Pi8Nm/aIk8LD0QXzI5N7HhFfidOTgDS8Mt1HgfxmTk4wUXZ/KvCCshqjimzMc/s9i9wPZX9UqqcfrpZkmwz8dzhm1bndN45ZOCy6xAYT6dzf8T4mLMDjVWSW4+DUoW4sYHRLVujjcMk7ybcwGV43VruPTJnc8XVAhT+VIMQkoPjhQmTOn8h82LRNGYtLa5RReCh9OPKVYB2Quz18FXMWgFt7A6VWudL0c7/8CusLvuo+pLcxt9pnV40rvu1YEohpEj8qR/qTSaDUBZM0J9SVf5zrZR80pZUnXkDF8nm+mcLOTley3YWipU19lCR7dzVyCAiQdVAuNPdnyem3Yk8enGkAJbfLd6eaIDs+p73D0JXh1Nx1px1movVLQH3ohIw="
     - secure: "w1614pomHLltkBhqWM2bOvbymFWIWKqSqqIBDvaNn9tbQScioItJoELBT7g7+cD7nyU7OvpQ1U2fk0xVkCeNvYU0xS1vP4o/VnZRpup7f7Tkiq+2rf4fjwYr3HHnJjwak1l9bsw6FkgzKaVvSdiUJHMVxiIuLd3fVozR7qjBBhTDxSlWGOpSgd+ttpgMZwU5zQjdaVQr1D7E8M0979ZnWMrNRyLiAUeHaPILS815b+ijgqR+i5nmu0/FTCGM9Ik4KIzIfWq8AdfPdbRiq8c+LrrTPfyKcIQJaHmfduYRM4LycGWwzkXFBNtLrJ7uFLG9RDVemOHuHOWIJX8qCUIV4XuESXxH3fUQr6r+yxquTJbzXxNtoaLa6tBOTQWKDrRjT4z9Mf9Im14F2V59EUDoQowHx5bjunOH5wg3ruYNKYYBFRYra5kx0CkKrqFBzyl8fTUEQLyx1HWTVUC1WTXEeD/aFKOSIxW5DxZr5W4LLlW2+Raa52ZzY28Q6AdueFQCRzoJ70/GsJRlSsBdWNOHN4gSp1cZuToLWY15y64QhAMVDpikB+V4hmkbceLiTqeWzTStNL1sa32RHr6i/9zeFZw1pMD1+eOg9x6fgODfh2sqr/zPbu2oONsHnc4D2jwsEax4o+Dv5QHLvK7jdyWUmu47a9QReoexXK60jZXs3CA="
 
+# use YAML aliases and anchors to avoid duplication in stages
+# c.f. https://github.com/travis-ci/travis-ci/issues/8295#issuecomment-454457787
+manylinux-build: &manylinux-build
+      stage: "Build manylinux images"
+      before_install:
+        # Load cached docker images
+        - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+      script:
+        - PLATFORM=$PLATFORM TRAVIS_COMMIT=$TRAVIS_COMMIT ./build.sh
+      deploy:
+        provider: script
+        script: docker/deploy.sh
+        on:
+          branch: master
+          repo: pypa/manylinux
+
 jobs:
   include:
     - stage: "Patch glibc"
@@ -33,17 +49,9 @@ jobs:
       before_cache:
         # Save tagged docker images
         - mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep 'centos-with-vsyscall:latest' | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
-    - stage: "Build manylinux images"
+    - <<: *manylinux-build
       env:
         - PLATFORM="x86_64"
-      before_install:
-        # Load cached docker images
-        - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
-      script:
-        - PLATFORM=$PLATFORM TRAVIS_COMMIT=$TRAVIS_COMMIT ./build.sh
-      deploy:
-        provider: script
-        script: docker/deploy.sh
-        on:
-          branch: master
-          repo: pypa/manylinux
+    - <<: *manylinux-build
+      env:
+        - PLATFORM="i686"

--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -1,0 +1,27 @@
+FROM i386/centos:6
+LABEL maintainer="The ManyLinux project"
+
+ENV AUDITWHEEL_ARCH i686
+ENV AUDITWHEEL_PLAT manylinux2010_$AUDITWHEEL_ARCH
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV DEVTOOLSET_ROOTPATH /opt/rh/devtoolset-7/root
+ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
+ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib
+ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
+
+# Set a base architecture of yum package to i386
+RUN echo "i386" > /etc/yum/vars/basearch
+
+# To have linux32 command 
+RUN yum -y update && \
+    yum install -y util-linux-ng
+
+COPY build_scripts /build_scripts
+RUN linux32 bash build_scripts/build.sh && rm -r build_scripts
+
+ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+ENTRYPOINT ["linux32"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -2,12 +2,14 @@
 FROM quay.io/pypa/manylinux2010_centos-6-no-vsyscall
 LABEL maintainer="The ManyLinux project"
 
-ENV AUDITWHEEL_PLAT manylinux2010_x86_64
+ENV AUDITWHEEL_ARCH x86_64
+ENV AUDITWHEEL_PLAT manylinux2010_$AUDITWHEEL_ARCH
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV PATH /opt/rh/devtoolset-8/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH /opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
+ENV DEVTOOLSET_ROOTPATH /opt/rh/devtoolset-8/root
+ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
+ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib64/dyninst:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 COPY build_scripts /build_scripts


### PR DESCRIPTION
I roughly manage to create a manylinux2010-i686 docker image based on CentOS 6. CentOS 6 is pretty old and i686 doesn't get enough attention so there are a couple of issues to be resolved unlike x86_64.

- There is no i686 devtoolset-8 in SCL so I replaced it with the devtoolsset-7 in cloud linux repo. Having the same version would be the best but 7.3 is still much better than built-in gcc 4.4.
- ~~CentOS 6 has a problem on curl with installed certificates so I have to add "-k" option to curl as a workaround. (I tried to update the existing system certificate but it didn't work)~~
- auditwheel doesn't have a proper list of symbols for i686. [PR](https://github.com/pypa/auditwheel/pull/194) is now ready.
- CentOS 6 32bit doesn't seem to have a vsyscall=emualate issue unlike x86_64 so it can run smoothly without the monkey patch that x86_64 base image has.

Any suggestion to enhance this is welcome!