### PR TITLE
Remove external typing package for python 3.7

### DIFF
--- a/docker/build_scripts/py37-requirements.txt
+++ b/docker/build_scripts/py37-requirements.txt
@@ -9,8 +9,3 @@ auditwheel==2.1.1 \
 # this package required for auditwheel
 pyelftools==0.25 \
     --hash=sha256:89c6da6f56280c37a5ff33468591ba9a124e17d71fe42de971818cbff46c1b24
-# this package required for auditwheel
-typing==3.7.4.1 \
-    --hash=sha256:91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23 \
-    --hash=sha256:c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36 \
-    --hash=sha256:f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714


### PR DESCRIPTION
Closes #377 

As mentioned in the `typing` package's documentation, it is meant for older versions of python. The documentation also says is should have NO EFFECT in newer versions of python, this is only true in some cases. The builtin python typing module works fine when called with subprocess, the `typing` package does not. See #377 for more details.

Edit: Should have pointed out that the recommended fix for the error discussed in #377 is to not install the typing package.