### PR TITLE
add s390x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
      env: PLATFORM="aarch64"
    - arch: ppc64le
      env: PLATFORM="ppc64le"
+   - arch: s390x
+     env: PLATFORM="s390x"
 
 script:
   - PLATFORM=$PLATFORM TRAVIS_COMMIT=$TRAVIS_COMMIT ./build.sh

--- a/docker/Dockerfile-s390x
+++ b/docker/Dockerfile-s390x
@@ -1,0 +1,19 @@
+FROM s390x/centos:7
+LABEL maintainer="The ManyLinux project"
+
+ENV AUDITWHEEL_ARCH ppc64le
+ENV AUDITWHEEL_PLAT manylinux2014_$AUDITWHEEL_ARCH
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV DEVTOOLSET_ROOTPATH /opt/rh/devtoolset-8/root
+ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
+ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib64/dyninst:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
+ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
+
+COPY build_scripts /build_scripts
+RUN bash build_scripts/build.sh && rm -r build_scripts
+
+ENV SSL_CERT_FILE=/opt/_internal/certs.pem
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Travis recently added s390x support, which appears as an option in the [PEP 599 manylinux2014](https://www.python.org/dev/peps/pep-0599/#the-manylinux2014-policy) spec. Add a build for it.