### PR TITLE
Add a note about python 3.8 ABI dropping the m flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ are also encountered in the wild. Other less common or virtually
 unheard of flag combinations (such as ``--with-pydebug`` (``d``) and
 ``--without-pymalloc`` (absence of ``m``)) are not provided.
 
+Note that `starting with CPython 3.8 <https://docs.python.org/dev/whatsnew/3.8.html#build-and-c-api-changes>`_,
+default ``sys.abiflags`` became an empty string: the ``m`` flag for pymalloc
+became useless (builds with and without pymalloc are ABI compatible) and so has
+been removed. (e.g. ``/opt/python/cp38-cp38``)
+
 Building Docker images
 ----------------------
 


### PR DESCRIPTION
This follows issues #393 and #372 which might have been opened due to lack of documentation.