### PR TITLE
Fix link to manylinux1 i686 Docker image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ x86-64 image: ``quay.io/pypa/manylinux1_x86_64``
 .. image:: https://quay.io/repository/pypa/manylinux1_x86_64/status
    :target: https://quay.io/repository/pypa/manylinux1_x86_64
 
-i686 image: ``quay.io/pypa/manylinux1_i386``
+i686 image: ``quay.io/pypa/manylinux1_i686``
 
 .. image:: https://quay.io/repository/pypa/manylinux1_i686/status
    :target: https://quay.io/repository/pypa/manylinux1_i686


### PR DESCRIPTION
Fixes a typo in the readme. `quay.io/pypa/manylinux1_i386` does not exist:
```
$ docker pull quay.io/pypa/manylinux1_i386
Using default tag: latest
Error response from daemon: unauthorized: access to the requested resource is not authorized
$ docker pull quay.io/pypa/manylinux1_i686
Using default tag: latest
latest: Pulling from pypa/manylinux1_i686
8a7625023db4: Already exists
0c59dcf84697: Already exists
7c4b9c038e24: Already exists
74bce53436e1: Already exists
Digest: sha256:1c9cbcb142a60095a074254629af8b8318f1f4f5e1e5a7a98444a58ee66fef4a
Status: Image is up to date for quay.io/pypa/manylinux1_i686:latest
```