### PR TITLE
Update OpenSSL from 1.0.2t to 1.0.2u (manylinux1)

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -6,8 +6,8 @@ CPYTHON_VERSIONS="2.7.17 3.4.10 3.5.9 3.6.10 3.7.6 3.8.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.
-OPENSSL_ROOT=openssl-1.0.2t
-OPENSSL_HASH=14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc
+OPENSSL_ROOT=openssl-1.0.2u
+OPENSSL_HASH=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
 PATCHELF_VERSION=0.10


### PR DESCRIPTION
Fixes security issues

This is the last release of OpenSSL 1.0.2 which is now EOL: https://mta.openssl.org/pipermail/openssl-announce/2019-December/000165.html

Moving to OpenSSL 1.1.1 will require dropping python 3.4