### PR TITLE
Update OpenSSL from 1.0.2u to 1.1.1d

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -6,8 +6,8 @@ CPYTHON_VERSIONS="2.7.17 3.5.9 3.6.10 3.7.6 3.8.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.
-OPENSSL_ROOT=openssl-1.0.2u
-OPENSSL_HASH=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
+OPENSSL_ROOT=openssl-1.1.1d
+OPENSSL_HASH=1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
 PATCHELF_VERSION=0.10

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -104,7 +104,7 @@ function build_cpythons {
 
 
 function do_openssl_build {
-    ./config no-ssl2 no-shared -fPIC --prefix=/usr/local/ssl > /dev/null
+    ./config no-shared -fPIC --prefix=/usr/local/ssl > /dev/null
     make > /dev/null
     make install_sw > /dev/null
 }


### PR DESCRIPTION
OpenSSL 1.0.2 series has reached end-of-life in December 2019
Relates to #429 

Builds on top of #438 