### PR TITLE
Image versioning: Tag each docker build with a unique id, and push that to quay.io

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-docker login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
 tag="quay.io/pypa/manylinux2010_$PLATFORM"
+build_id=$(git show -s --format=%cd-%h --date=short $TRAVIS_COMMIT)
+
+docker login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
+docker tag ${tag}:${TRAVIS_COMMIT} ${tag}:${build_id}
 docker tag ${tag}:${TRAVIS_COMMIT} ${tag}:latest
+docker push ${tag}:${build_id}
 docker push ${tag}:latest


### PR DESCRIPTION
Over at cibuildwheel we've been talking about how we might get some determinism in the build process (https://github.com/joerick/cibuildwheel/issues/239), and the manylinux image is one of those things we'd like to lock down.

This PR introduces a docker tag, alongside `latest`, of the format `YYYY-MM-dd-gitsha`, for example `2020-01-18-dea2616`. Each build is tagged, and the tag is pushed to quay.io.

I have tested this on my fork, with Travis building and uploading - see https://quay.io/repository/joerick/manylinux2010_x86_64?tab=tags for how these end up in quay.io.

Thanks!

Fixes #111 
