### PR TITLE
Use https://bootstrap.pypa.io/3.4/get-pip.py for cp34

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -38,3 +38,4 @@ GIT_HASH=7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a
 GIT_DOWNLOAD_URL=https://github.com/git/git/archive
 
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+GET_PIP_URL_CP34=https://bootstrap.pypa.io/3.4/get-pip.py

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -54,7 +54,13 @@ function do_cpython_build {
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
     fi
-    ${prefix}/bin/python get-pip.py
+    if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3.4) ] && [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.5) ]; then
+        check_var $GET_PIP_URL_CP34
+        curl -fsSL $GET_PIP_URL_CP34 | ${prefix}/bin/python
+    else
+        ${prefix}/bin/python get-pip.py
+    fi
+
     if [ -e ${prefix}/bin/pip3 ] && [ ! -e ${prefix}/bin/pip ]; then
         ln -s pip3 ${prefix}/bin/pip
     fi


### PR DESCRIPTION
https://bootstrap.pypa.io/get-pip.py does not work anymore for cp34