### PR TITLE
Use https://bootstrap.pypa.io/3.4/get-pip.py for cp34 (manylinux1)

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -40,5 +40,7 @@ GIT_HASH=7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a
 GIT_DOWNLOAD_URL=https://github.com/git/git/archive
 
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+GET_PIP_URL_CP34=https://bootstrap.pypa.io/3.4/get-pip.py
+
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -54,10 +54,17 @@ function do_cpython_build {
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
     fi
-    # --force-reinstall is to work around:
-    #   https://github.com/pypa/pip/issues/5220
-    #   https://github.com/pypa/get-pip/issues/19
-    ${prefix}/bin/python get-pip.py --force-reinstall
+
+    if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3.4) ] && [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.5) ]; then
+        check_var $GET_PIP_URL_CP34
+        curl -fsSL $GET_PIP_URL_CP34 | ${prefix}/bin/python
+    else
+        # --force-reinstall is to work around:
+        #   https://github.com/pypa/pip/issues/5220
+        #   https://github.com/pypa/get-pip/issues/19
+        ${prefix}/bin/python get-pip.py --force-reinstall
+    fi
+
     if [ -e ${prefix}/bin/pip3 ] && [ ! -e ${prefix}/bin/pip ]; then
         ln -s pip3 ${prefix}/bin/pip
     fi


### PR DESCRIPTION
https://bootstrap.pypa.io/get-pip.py does not work anymore for cp34