### PR TITLE
Remove Python 3.4

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -2,7 +2,7 @@
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 # of the form <maj>.<min>.<rev> or <maj>.<min>.<rev>rc<n>
-CPYTHON_VERSIONS="2.7.17 3.4.10 3.5.9 3.6.10 3.7.6 3.8.1"
+CPYTHON_VERSIONS="2.7.17 3.5.9 3.6.10 3.7.6 3.8.1"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -54,12 +54,7 @@ function do_cpython_build {
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
     fi
-    if [ $(lex_pyver $py_ver) -ge $(lex_pyver 3.4) ] && [ $(lex_pyver $py_ver) -lt $(lex_pyver 3.5) ]; then
-        check_var $GET_PIP_URL_CP34
-        curl -fsSL $GET_PIP_URL_CP34 | ${prefix}/bin/python
-    else
-        ${prefix}/bin/python get-pip.py
-    fi
+    ${prefix}/bin/python get-pip.py
 
     if [ -e ${prefix}/bin/pip3 ] && [ ! -e ${prefix}/bin/pip ]; then
         ln -s pip3 ${prefix}/bin/pip


### PR DESCRIPTION
CPython 3.4 has reached EOL in March 2019.

Closes: #427 