### PR TITLE
use ensurepip, other small cleanups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,9 @@ distro -- CentOS 6.
 
 
 Rather than forcing you to install CentOS 6 yourself, install Python,
-etc., we provide a `Docker <https://docker.com/>`_ image where we've
-done the work for you:
+etc., we provide `Docker <https://docker.com/>`_ images where we've
+done the work for you. The images are uploaded to `quay.io`_ and are tagged
+for repeatable builds.
 
 manylinux1
 ~~~~~~~~~~
@@ -110,7 +111,7 @@ directory for source code.
 
 The images currently contain:
 
-- CPython 2.7, 3.4, 3.5, 3.6, 3.7 & 3.8, installed in
+- CPython 2.7, 3.5, 3.6, 3.7 & 3.8, installed in
   ``/opt/python/<python tag>-<abi tag>``. The directories are named
   after the PEP 425 tags for each environment --
   e.g. ``/opt/python/cp27-cp27mu`` contains a wide-unicode CPython 2.7
@@ -199,3 +200,4 @@ trackers, chat rooms, and mailing lists is expected to follow the
 `PyPA Code of Conduct`_.
 
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct
+.. _`quay.io`: https://quay.io/organization/pypa

--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -36,6 +36,3 @@ LIBXCRYPT_HASH=7da15438d93883be434b0b44a8c22f726b5f605c6d88a315e17d4f4e929c20a8
 GIT_ROOT=2.23.0
 GIT_HASH=7d84f5d6f48e95b467a04a8aa1d474e0d21abc7877998af945568d2634fea46a
 GIT_DOWNLOAD_URL=https://github.com/git/git/archive
-
-GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
-GET_PIP_URL_CP34=https://bootstrap.pypa.io/3.4/get-pip.py

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -54,12 +54,12 @@ function do_cpython_build {
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
     fi
-    ${prefix}/bin/python get-pip.py
+    ${prefix}/bin/python -mensurepip
 
     if [ -e ${prefix}/bin/pip3 ] && [ ! -e ${prefix}/bin/pip ]; then
         ln -s pip3 ${prefix}/bin/pip
     fi
-    # Since we fall back on a canned copy of get-pip.py, we might not have
+    # Since we fall back on a canned copy of pip, we might not have
     # the latest pip and friends. Upgrade them to make sure.
     ${prefix}/bin/pip install -U --require-hashes -r ${MY_DIR}/requirements.txt
     local abi_tag=$(${prefix}/bin/python ${MY_DIR}/python-tag-abi-tag.py)
@@ -87,8 +87,6 @@ function build_cpython {
 
 
 function build_cpythons {
-    check_var $GET_PIP_URL
-    curl -fsSLO $GET_PIP_URL
     # Import public keys used to verify downloaded Python source tarballs.
     # https://www.python.org/static/files/pubkeys.txt
     gpg --import ${MY_DIR}/cpython-pubkeys.txt
@@ -99,7 +97,6 @@ function build_cpythons {
     done
     # Remove GPG hidden directory.
     rm -rf /root/.gnupg/
-    rm -f get-pip.py
 }
 
 

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -54,7 +54,7 @@ function do_cpython_build {
     if [ -e ${prefix}/bin/python3 ]; then
         ln -s python3 ${prefix}/bin/python
     fi
-    ${prefix}/bin/python -mensurepip
+    ${prefix}/bin/python -m ensurepip
 
     if [ -e ${prefix}/bin/pip3 ] && [ ! -e ${prefix}/bin/pip ]; then
         ln -s pip3 ${prefix}/bin/pip

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -61,7 +61,11 @@ function do_cpython_build {
     fi
     # Since we fall back on a canned copy of pip, we might not have
     # the latest pip and friends. Upgrade them to make sure.
-    ${prefix}/bin/pip install -U --require-hashes -r ${MY_DIR}/requirements.txt
+    if [ "${py_ver:0:1}" == "2" ]; then
+        ${prefix}/bin/pip install -U --require-hashes -r ${MY_DIR}/py27-requirements.txt
+    else
+        ${prefix}/bin/pip install -U --require-hashes -r ${MY_DIR}/requirements.txt
+    fi
     local abi_tag=$(${prefix}/bin/python ${MY_DIR}/python-tag-abi-tag.py)
     ln -s ${prefix} /opt/python/${abi_tag}
 }

--- a/docker/build_scripts/py27-requirements.txt
+++ b/docker/build_scripts/py27-requirements.txt
@@ -1,0 +1,11 @@
+# pip requirements for python2.7
+# NOTE: pip has GPG signatures; could download and verify independently.
+pip==20.0.2 \
+    --hash=sha256:4ae14a42d8adba3205ebeb38aa68cfc0b6c346e1ae2e699a0b3bad4da19cef5c \
+    --hash=sha256:7db0c8ea4c7ea51c8049640e8e6e7fde949de672bfa4949920675563a5a6967f
+wheel==0.31.1 \
+    --hash=sha256:80044e51ec5bbf6c894ba0bc48d26a8c20a9ba629f4ca19ea26ecfcf87685f5f \
+    --hash=sha256:0a2e54558a0628f2145d2fc822137e322412115173e8a2ddbe1c9024338ae83c
+setuptools==43.0.0 \
+    --hash=sha256:a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963 \
+    --hash=sha256:db45ebb4a4b3b95ff0aca3ce5fe1e820ce17be393caf8902c78aa36240e8c378

--- a/docker/build_scripts/py37-requirements.txt
+++ b/docker/build_scripts/py37-requirements.txt
@@ -8,3 +8,6 @@ auditwheel==3.0.0 \
 # this package required for auditwheel
 pyelftools==0.26 \
     --hash=sha256:cc0ea0de82b240a73ef4056fce44acbb4727dca7d66759371aff2bad457ed711
+wheel==0.31.1 \
+    --hash=sha256:80044e51ec5bbf6c894ba0bc48d26a8c20a9ba629f4ca19ea26ecfcf87685f5f \
+    --hash=sha256:0a2e54558a0628f2145d2fc822137e322412115173e8a2ddbe1c9024338ae83c


### PR DESCRIPTION
- document quay.io/organization/pypa for easy reference
- remove 3.4 from the documents
- replace get-pip with ensurepip
- add a hash for wheel
- pin python2.7 requirements since setuptools 46 doesn't support it xref gh-491)