### PR TITLE
Pin py27-requirements.txt to python == 2.7

### DIFF
--- a/docker/build_scripts/py27-requirements.txt
+++ b/docker/build_scripts/py27-requirements.txt
@@ -1,11 +1,11 @@
 # pip requirements for python2.7
 # NOTE: pip has GPG signatures; could download and verify independently.
-pip==20.0.2 \
+pip==20.0.2 ; python_version=='2.7' \
     --hash=sha256:4ae14a42d8adba3205ebeb38aa68cfc0b6c346e1ae2e699a0b3bad4da19cef5c \
     --hash=sha256:7db0c8ea4c7ea51c8049640e8e6e7fde949de672bfa4949920675563a5a6967f
-wheel==0.34.2 \
+wheel==0.34.2 ; python_version=='2.7' \
     --hash=sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e \
     --hash=sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96
-setuptools==44.1.0 \
+setuptools==44.1.0 ; python_version=='2.7' \
     --hash=sha256:992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30 \
     --hash=sha256:794a96b0c1dc6f182c36b72ab70d7e90f1d59f7a132e6919bb37b4fd4d424aca


### PR DESCRIPTION
Prevent dependabot from upgrading to incompatible versions (hopefully)