### PR TITLE
Apply patch in patchelf to avoid zeroing SONAME

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -158,12 +158,8 @@ export SSL_CERT_FILE=/opt/_internal/certs.pem
 # Now we can delete our built OpenSSL headers/static libs since we've linked everything we need
 rm -rf /usr/local/ssl
 
-# Install patchelf (latest with unreleased bug fixes)
-curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/archive/$PATCHELF_VERSION.tar.gz
-check_sha256sum patchelf.tar.gz $PATCHELF_HASH
-tar -xzf patchelf.tar.gz
-(cd patchelf-$PATCHELF_VERSION && ./bootstrap.sh && do_standard_install)
-rm -rf patchelf.tar.gz patchelf-$PATCHELF_VERSION
+# Install patchelf (latest with unreleased bug fixes) and apply our patches
+build_patchelf $PATCHELF_VERSION $PATCHELF_HASH
 
 ln -s $PY37_BIN/auditwheel /usr/local/bin/auditwheel
 

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -228,3 +228,14 @@ function build_libxcrypt {
     rm -rf /usr/include/crypt.h
     rm -rf /usr/lib64/libcrypt.a /usr/lib64/libcrypt.so
 }
+
+function build_patchelf {
+    local patchelf_version=$1
+    local patchelf_hash=$2
+    local src_dir=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
+    curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/archive/$patchelf_version.tar.gz
+    check_sha256sum patchelf.tar.gz $patchelf_hash
+    tar -xzf patchelf.tar.gz
+    (cd patchelf-$patchelf_version && patch -p1 -i "$src_dir"/patches/patchelf-remove-zeroing.diff && ./bootstrap.sh && do_standard_install)
+    rm -rf patchelf.tar.gz patchelf-$patchelf_version
+}

--- a/docker/build_scripts/patches/patchelf-remove-zeroing.diff
+++ b/docker/build_scripts/patches/patchelf-remove-zeroing.diff
@@ -1,0 +1,19 @@
+Patch from https://github.com/NixOS/patchelf/pull/171
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 0b4965a..592799d 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -1074,13 +1074,6 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
+         return;
+     }
+ 
+-    /* Zero out the previous SONAME */
+-    unsigned int sonameSize = 0;
+-    if (soname) {
+-        sonameSize = strlen(soname);
+-        memset(soname, 'X', sonameSize);
+-    }
+-
+     debug("new SONAME is '%s'\n", newSoname.c_str());
+ 
+     /* Grow the .dynstr section to make room for the new SONAME. */


### PR DESCRIPTION
This patch is a copy of the upstream PR
https://github.com/NixOS/patchelf/pull/171. This fixes a bug in patchelf
which causes an SONAME entry filled with 'X' values.

This patch in `patchelf`fixes https://github.com/pypa/auditwheel/issues/159 until the patch is applied upstream.