### PR TITLE
[manylinux2010] Update OpenSSL from 1.1.1f to 1.1.1g

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -6,8 +6,8 @@ CPYTHON_VERSIONS="2.7.17 3.5.9 3.6.10 3.7.7 3.8.2"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.
-OPENSSL_ROOT=openssl-1.1.1f
-OPENSSL_HASH=186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35
+OPENSSL_ROOT=openssl-1.1.1g
+OPENSSL_HASH=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
 PATCHELF_VERSION=0.10


### PR DESCRIPTION
Changelog: https://www.openssl.org/news/cl111.txt