### PR TITLE
Add linux32 entrypoint on i686 image

### DIFF
--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -21,4 +21,5 @@ RUN linux32 bash build_scripts/build.sh && rm -r build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 
+ENTRYPOINT ["linux32"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
The i686 image for manylinux2014 is missing the linux32 entry point resulting in
```
docker run quay.io/pypa/manylinux2014_i686:latest uname -m
```
to return
```
x86_64
```
instead of
```
i686
```
Fix #557