### PR TITLE
Add libgfortran4 for devtoolset-7 compatibility

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -60,6 +60,8 @@ x86_64)
   yum -y install centos-release-scl
   ;;
 i686)
+  # Add libgfortran4 for devtoolset-7 compat
+  yum -y install libgfortran4
   # Install mayeut/devtoolset-8 repo to get devtoolset-8
   curl -fsSLo /etc/yum.repos.d/mayeut-devtoolset-8.repo https://copr.fedorainfracloud.org/coprs/mayeut/devtoolset-8/repo/epel-6/mayeut-devtoolset-8-epel-6.repo
   ;;


### PR DESCRIPTION
Provides backward compatibility with previous builds using `devtoolset-7`.
Use-case: `numpy` caching an `openblas` built with `devtoolset-7` linking with `libgfortran4` rather than `libgfortran5` 

Fix #570 