### PR TITLE
[manylinux2014] Build a libcrypt.so.1 that suitable for grafting

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -112,7 +112,7 @@ cd ..
 rm -rf $SQLITE_AUTOCONF_VERSION*
 rm /usr/local/lib/libsqlite3.a
 
-# Install libcrypt.so.2
+# Install libcrypt.so.1 and libcrypt.so.2
 build_libxcrypt "$LIBXCRYPT_DOWNLOAD_URL" "$LIBXCRYPT_VERSION" "$LIBXCRYPT_HASH"
 
 # Compile the latest Python releases.

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -178,16 +178,28 @@ function build_libxcrypt {
     curl -fsSLO "$LIBXCRYPT_DOWNLOAD_URL"/v"$LIBXCRYPT_VERSION"
     check_sha256sum "v$LIBXCRYPT_VERSION" "$LIBXCRYPT_HASH"
     tar xfz "v$LIBXCRYPT_VERSION"
-    (cd "libxcrypt-$LIBXCRYPT_VERSION" && ./autogen.sh && \
-        do_standard_install \
+    pushd "libxcrypt-$LIBXCRYPT_VERSION"
+    ./autogen.sh > /dev/null
+    do_standard_install \
         --disable-obsolete-api \
         --enable-hashes=all \
-        --disable-werror)
+        --disable-werror
+    # we also need libcrypt.so.1 with glibc compatibility for system libraries
+    # c.f https://github.com/pypa/manylinux/issues/305#issuecomment-625902928
+    make clean > /dev/null
+    sed -r -i 's/XCRYPT_([0-9.])+/-/g;s/(%chain OW_CRYPT_1.0).*/\1/g' lib/libcrypt.map.in
+    DESTDIR=$(pwd)/so.1 do_standard_install \
+        --disable-xcrypt-compat-files \
+        --enable-obsolete-api=glibc \
+        --enable-hashes=all \
+        --disable-werror
+    cp -P ./so.1/usr/local/lib/libcrypt.so.1* /usr/local/lib/
+    popd
     rm -rf "v$LIBXCRYPT_VERSION" "libxcrypt-$LIBXCRYPT_VERSION"
 
     # Delete GLIBC version headers and libraries
     rm -rf /usr/include/crypt.h
-    rm -rf /usr/lib64/libcrypt.a /usr/lib64/libcrypt.so
+    rm -rf /usr/lib*/libcrypt.a /usr/lib*/libcrypt.so /usr/lib*/libcrypt.so.1
 }
 
 function build_patchelf {


### PR DESCRIPTION
With libcrypt.so.1 being removed from the whitelist of auditwheel, system libcrypt.so.1 cannot be grafted as it relies on GLIBC_PRIVATE symbols.
This rebuilds a suitable replacement for libcrypt.so.1

Fix #411
Relates to #305 
Relates to pypa/auditwheel#230