### PR TITLE
Specify client-side pip version requirements for tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,17 @@ Code and details regarding ``manylinux1`` can be found here:
 Wheel packages compliant with those tags can be uploaded to
 `PyPI <https://pypi.python.org>`_ (for instance with `twine
 <https://pypi.python.org/pypi/twine>`_) and can be installed with
-**pip 19.0 and later**.
+pip:
+
++-------------------+----------------------------------+
+| ``manylinux`` tag | Client-side pip version required |
++===================+==================================+
+| ``manylinux2014`` | pip >= 19.3                      |
++-------------------+----------------------------------+
+| ``manylinux2010`` | pip >= 19.0                      |
++-------------------+----------------------------------+
+| ``manylinux1``    | pip >= 8.1.0                     |
++-------------------+----------------------------------+
 
 The manylinux2010 tags allow projects to distribute wheels that are
 automatically installed (and work!) on the vast majority of desktop


### PR DESCRIPTION
While the README emphasizes manylinux2010 tags as a
result of 40b86fb7f4a77c734c24376231388c1effb11a13,
the mention of manylinux requiring pip >= 19 doesn't
tie itself to a specific manylinux tag, and is
ambiguous especially considering that manylinux1
is still the most common format as of 2020.

This table (taken from the pip changelog at
https://pip.pypa.io/en/stable/news/) makes the
relationship clearer while still allowing the
README to emphasize manylinux2010 in other places.