### PR TITLE
Fix localedef not being found on s390x image

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -52,6 +52,11 @@ yum -y update
 yum -y install yum-utils curl
 yum-config-manager --enable extras
 
+if ! which localedef &> /dev/null; then
+    # somebody messed up glibc-common package to squeeze image size, reinstall the package
+    yum -y reinstall glibc-common
+fi
+
 # upgrading glibc-common can end with removal on en_US.UTF-8 locale
 localedef -i en_US -f UTF-8 en_US.UTF-8
 


### PR DESCRIPTION
Fixes issue seen in https://github.com/pypa/manylinux/pull/597#issuecomment-628651499 following s390x image update on docker hub.