### PR TITLE
Manylinux2014_aarch64: patch patchelf to fix alignment issues on Arm64

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -248,6 +248,6 @@ function build_patchelf {
     curl -fsSL -o patchelf.tar.gz https://github.com/NixOS/patchelf/archive/$patchelf_version.tar.gz
     check_sha256sum patchelf.tar.gz $patchelf_hash
     tar -xzf patchelf.tar.gz
-    (cd patchelf-$patchelf_version && ./bootstrap.sh && do_standard_install)
+    (cd patchelf-$patchelf_version && patch -p1 -i "$src_dir"/patches/patchelf-fix-default-aarch64-alignment.patch && ./bootstrap.sh && do_standard_install)
     rm -rf patchelf.tar.gz patchelf-$patchelf_version
 }

--- a/docker/build_scripts/patches/patchelf-fix-default-aarch64-alignment.patch
+++ b/docker/build_scripts/patches/patchelf-fix-default-aarch64-alignment.patch
@@ -1,0 +1,939 @@
+From b65acdd6e911348594425925fa6ee65aa31654ea Mon Sep 17 00:00:00 2001
+From: "Aaron D. Marasco" <github-patchelf@marascos.net>
+Date: Wed, 10 Jun 2020 09:35:06 -0400
+Subject: [PATCH] Squash commit for all commits since 0.11
+
+Add libasan build option and test print-needed
+
+(cherry picked from commit 288eb61a173ce6f4cdf0be0d744c9c6b6b5598a4)
+
+Fixed tests to be running with parallel-tests
+
+Set automake and autoconf versions required for parallel-tests
+
+Some const-correctness and C++11 auto
+
+(cherry picked from commit 76e2cdbee4705c45cae4eca55278530a02be2f83)
+
+Improve the default section alignment choice
+
+Currently patchelf uses the host system's page size (determined at build
+time) as the default section load memory alignment. This causes multiple
+issues
+
+- Cross-compilation: when using patchelf on ELFs targetting a different
+  architecture from the host, the host page size is still used by
+  default.
+
+- Variable page size architectures: ARMv8 systems can be configured in
+  either 4K, 16K, or 64K page size mode depending on kernel
+  configuration. An ARMv8 patchelf built on a 4K page size system will
+  end up creating ELFs that cannot be used on a 64K page size system.
+
+- Reproducibility: the page size of the machine that built patchelf
+  "leaks" into the binary.
+
+The build time --with-page-size as well as the run time --page-size
+options can be used to work around some of these issues. But it's much
+better to have patchelf do the right thing without explicit
+configuration.
+
+This commit adds support for inferring page size from the ELF header's
+"machine" field. The default values are extracted from GNU gold's source
+code. Note that both --with-page-size as well as --page-size continue to
+work and take precedence on the default value.
+
+CI for aarch64
+
+Better support relocating NOTE sections/segments
+
+SHT_NOTE sections can be mapped in memory by PT_NOTE segments. When
+rewriting an SHT_NOTE, attempt to also rewrite a matching segment if it
+exists.
+
+Note that an ELF can contain multiple SHT_NOTE sections, and a given
+PT_NOTE segment can theoretically map multiple contiguous sections.
+There are multiple ways this could be handled, the one picked here is to
+pre-normalize PT_NOTE segments so that a multi-section segment gets
+broken up into multiple separate segments instead.
+
+Also fix (or more like hack around) alignment issues with note sections.
+Keeping the original alignment value when possible is important because
+it determines how the data within the section needs to be parsed.
+
+add regression test for NOTE section relocation
+
+fix nix develop evaluation
+
+use stable_sort to maintain relative order for equal elemnts in sections(&segments)
+
+add --clear-symbol-version
+
+This sets the versym entry for a given symbol to 1.
+
+remove unused DT_IGNORE.
+
+patchelf: Check ELF endianness before writing new runpath
+
+This commit modifies the way fields are written in the dynamic
+section in order to account the architecture of the target ELF
+file. Instead of copying the raw data, use the helper functions
+to convert endianness.
+
+Signed-off-by: Bryce Ferguson <bryce.ferguson@rockwellcollins.com>
+
+skip overwriting r(un)path data when old_rpath = new_rpath.
+
+Also handle the case of dyn rpath changed.
+---
+ .travis.yml                |   4 +
+ configure.ac               |  23 ++-
+ release.nix                |   5 +-
+ src/Makefile.am            |   4 +
+ src/patchelf.cc            | 299 ++++++++++++++++++++++++++++---------
+ tests/Makefile.am          |   9 +-
+ tests/build-id.sh          |  19 +++
+ tests/no-rpath-prebuild.sh |   2 +-
+ tests/plain-needed.sh      |   4 +
+ 9 files changed, 285 insertions(+), 84 deletions(-)
+ create mode 100644 .travis.yml
+ create mode 100755 tests/build-id.sh
+ create mode 100755 tests/plain-needed.sh
+
+diff --git a/.travis.yml b/.travis.yml
+new file mode 100644
+index 0000000..1585844
+--- /dev/null
++++ b/.travis.yml
+@@ -0,0 +1,4 @@
++arch:
++  - arm64
++language: nix
++script: nix-build release.nix -A build.aarch64-linux
+diff --git a/configure.ac b/configure.ac
+index c2e5e98..3af271f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,28 +1,27 @@
++AC_PREREQ([2.62])
+ AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
+ AC_CONFIG_SRCDIR([src/patchelf.cc])
+ AC_CONFIG_AUX_DIR([build-aux])
+-AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests serial-tests])
++AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
+ 
+ AM_PROG_CC_C_O
+ AC_PROG_CXX
+ 
+-PAGESIZE=auto
++DEFAULT_PAGESIZE=auto
+ AC_ARG_WITH([page-size],
+    AS_HELP_STRING([--with-page-size=SIZE], [Specify default pagesize (default auto)]),
+-   PAGESIZE=$withval
++   DEFAULT_PAGESIZE=$withval
+ )
+ 
+-if test "$PAGESIZE" = auto; then
+-    if command -v getconf >/dev/null; then
+-        PAGESIZE=$(getconf PAGESIZE || getconf PAGE_SIZE)
+-    fi
+-    if test "$PAGESIZE" = auto -o -z "$PAGESIZE"; then
+-        PAGESIZE=4096
+-    fi
++if test "$DEFAULT_PAGESIZE" != auto; then
++    AC_DEFINE_UNQUOTED(DEFAULT_PAGESIZE, ${DEFAULT_PAGESIZE})
++    AC_MSG_RESULT([Setting page size to ${DEFAULT_PAGESIZE}])
+ fi
+ 
+-AC_DEFINE_UNQUOTED(PAGESIZE, ${PAGESIZE})
+-AC_MSG_RESULT([Setting page size to ${PAGESIZE}])
++AC_ARG_WITH([asan],
++   AS_HELP_STRING([--with-asan], [Link with libasan])
++)
++AM_CONDITIONAL([WITH_ASAN], [test x"$with_asan" = xyes])
+ 
+ AC_CONFIG_FILES([Makefile src/Makefile tests/Makefile patchelf.spec])
+ AC_OUTPUT
+diff --git a/release.nix b/release.nix
+index 06bf91d..b556a8e 100644
+--- a/release.nix
++++ b/release.nix
+@@ -1,6 +1,7 @@
+ { patchelfSrc ? { outPath = ./.; revCount = 1234; shortRev = "abcdef"; }
+ , nixpkgs ? builtins.fetchTarball https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz
+ , officialRelease ? false
++, systems ? [ "x86_64-linux" "i686-linux" "aarch64-linux" ]
+ }:
+ 
+ let
+@@ -20,7 +21,7 @@ let
+                     ((if patchelfSrc ? lastModifiedDate
+                       then builtins.substring 0 8 patchelfSrc.lastModifiedDate
+                       else toString patchelfSrc.revCount or 0)
+-                    + "." + patchelfSrc.shortRev));
++                    + "." + (patchelfSrc.shortRev or "")));
+         versionSuffix = ""; # obsolete
+         src = patchelfSrc;
+         preAutoconf = "echo ${version} > version";
+@@ -39,7 +40,7 @@ let
+       };
+ 
+ 
+-    build = pkgs.lib.genAttrs [ "x86_64-linux" "i686-linux" "aarch64-linux" /* "x86_64-freebsd" "i686-freebsd"  "x86_64-darwin" "i686-solaris" "i686-cygwin" */ ] (system:
++    build = pkgs.lib.genAttrs systems (system:
+ 
+       with import nixpkgs { inherit system; };
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 7170cf3..b9aee08 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,5 +1,9 @@
+ AM_CXXFLAGS = -Wall -std=c++11 -D_FILE_OFFSET_BITS=64
+ 
++if WITH_ASAN
++AM_CXXFLAGS += -fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1
++endif
++
+ bin_PROGRAMS = patchelf
+ 
+ patchelf_SOURCES = patchelf.cc elf.h
+diff --git a/src/patchelf.cc b/src/patchelf.cc
+index 965686a..05ec793 100644
+--- a/src/patchelf.cc
++++ b/src/patchelf.cc
+@@ -48,13 +48,17 @@ static bool forceRPath = false;
+ static std::vector<std::string> fileNames;
+ static std::string outputFileName;
+ static bool alwaysWrite = false;
+-static int pageSize = PAGESIZE;
++#ifdef DEFAULT_PAGESIZE
++static int forcedPageSize = DEFAULT_PAGESIZE;
++#else
++static int forcedPageSize = -1;
++#endif
+ 
+ typedef std::shared_ptr<std::vector<unsigned char>> FileContents;
+ 
+ 
+-#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed
+-#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Verneed
++#define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym
++#define ElfFileParamNames Elf_Ehdr, Elf_Phdr, Elf_Shdr, Elf_Addr, Elf_Off, Elf_Dyn, Elf_Sym, Elf_Verneed, Elf_Versym
+ 
+ 
+ static std::vector<std::string> splitColonDelimitedString(const char * s)
+@@ -81,12 +85,6 @@ static bool hasAllowedPrefix(const std::string & s, const std::vector<std::strin
+ }
+ 
+ 
+-static unsigned int getPageSize()
+-{
+-    return pageSize;
+-}
+-
+-
+ template<ElfFileParams>
+ class ElfFile
+ {
+@@ -161,11 +159,13 @@ private:
+ 
+     friend struct CompShdr;
+ 
++    unsigned int getPageSize() const;
++
+     void sortShdrs();
+ 
+     void shiftFile(unsigned int extraPages, Elf_Addr startPage);
+ 
+-    std::string getSectionName(const Elf_Shdr & shdr);
++    std::string getSectionName(const Elf_Shdr & shdr) const;
+ 
+     Elf_Shdr & findSection(const SectionName & sectionName);
+ 
+@@ -176,7 +176,7 @@ private:
+     std::string & replaceSection(const SectionName & sectionName,
+         unsigned int size);
+ 
+-    bool haveReplacedSection(const SectionName & sectionName);
++    bool haveReplacedSection(const SectionName & sectionName) const;
+ 
+     void writeReplacedSections(Elf_Off & curOff,
+         Elf_Addr startAddr, Elf_Off startOffset);
+@@ -187,6 +187,8 @@ private:
+ 
+     void rewriteSectionsExecutable();
+ 
++    void normalizeNoteSegments();
++
+ public:
+ 
+     void rewriteSections();
+@@ -209,21 +211,23 @@ public:
+ 
+     void replaceNeeded(const std::map<std::string, std::string> & libs);
+ 
+-    void printNeededLibs();
++    void printNeededLibs() /* should be const */;
+ 
+     void noDefaultLib();
+ 
++    void clearSymbolVersions(const std::set<std::string> & syms);
++
+ private:
+ 
+     /* Convert an integer in big or little endian representation (as
+        specified by the ELF header) to this platform's integer
+        representation. */
+     template<class I>
+-    I rdi(I i);
++    I rdi(I i) const;
+ 
+     /* Convert back to the ELF representation. */
+     template<class I>
+-    I wri(I & t, unsigned long long i)
++    I wri(I & t, unsigned long long i) const
+     {
+         t = rdi((I) i);
+         return i;
+@@ -235,7 +239,7 @@ private:
+    why... */
+ template<ElfFileParams>
+ template<class I>
+-I ElfFile<ElfFileParamNames>::rdi(I i)
++I ElfFile<ElfFileParamNames>::rdi(I i) const
+ {
+     I r = 0;
+     if (littleEndian) {
+@@ -251,10 +255,6 @@ I ElfFile<ElfFileParamNames>::rdi(I i)
+ }
+ 
+ 
+-/* Ugly: used to erase DT_RUNPATH when using --force-rpath. */
+-#define DT_IGNORE       0x00726e67
+-
+-
+ static void debug(const char * format, ...)
+ {
+     if (debugMode) {
+@@ -444,13 +444,36 @@ ElfFile<ElfFileParamNames>::ElfFile(FileContents fileContents)
+ }
+ 
+ 
++template<ElfFileParams>
++unsigned int ElfFile<ElfFileParamNames>::getPageSize() const
++{
++    if (forcedPageSize > 0)
++        return forcedPageSize;
++
++    // Architectures (and ABIs) can have different minimum section alignment
++    // requirements. There is no authoritative list of these values. The
++    // current list is extracted from GNU gold's source code (abi_pagesize).
++    switch (hdr->e_machine) {
++      case EM_SPARC:
++      case EM_MIPS:
++      case EM_PPC:
++      case EM_PPC64:
++      case EM_AARCH64:
++      case EM_TILEGX:
++        return 0x10000;
++      default:
++        return 0x1000;
++    }
++}
++
++
+ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::sortPhdrs()
+ {
+     /* Sort the segments by offset. */
+     CompPhdr comp;
+     comp.elfFile = this;
+-    sort(phdrs.begin(), phdrs.end(), comp);
++    stable_sort(phdrs.begin(), phdrs.end(), comp);
+ }
+ 
+ 
+@@ -477,7 +500,7 @@ void ElfFile<ElfFileParamNames>::sortShdrs()
+     /* Sort the sections by offset. */
+     CompShdr comp;
+     comp.elfFile = this;
+-    sort(shdrs.begin() + 1, shdrs.end(), comp);
++    stable_sort(shdrs.begin() + 1, shdrs.end(), comp);
+ 
+     /* Restore the sh_link mappings. */
+     for (unsigned int i = 1; i < rdi(hdr->e_shnum); ++i)
+@@ -569,7 +592,7 @@ void ElfFile<ElfFileParamNames>::shiftFile(unsigned int extraPages, Elf_Addr sta
+ 
+ 
+ template<ElfFileParams>
+-std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr)
++std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr) const
+ {
+     return std::string(sectionNames.c_str() + rdi(shdr.sh_name));
+ }
+@@ -578,7 +601,7 @@ std::string ElfFile<ElfFileParamNames>::getSectionName(const Elf_Shdr & shdr)
+ template<ElfFileParams>
+ Elf_Shdr & ElfFile<ElfFileParamNames>::findSection(const SectionName & sectionName)
+ {
+-    Elf_Shdr * shdr = findSection2(sectionName);
++    auto shdr = findSection2(sectionName);
+     if (!shdr) {
+         std::string extraMsg = "";
+         if (sectionName == ".interp" || sectionName == ".dynamic" || sectionName == ".dynstr")
+@@ -592,7 +615,7 @@ Elf_Shdr & ElfFile<ElfFileParamNames>::findSection(const SectionName & sectionNa
+ template<ElfFileParams>
+ Elf_Shdr * ElfFile<ElfFileParamNames>::findSection2(const SectionName & sectionName)
+ {
+-    unsigned int i = findSection3(sectionName);
++    auto i = findSection3(sectionName);
+     return i ? &shdrs[i] : 0;
+ }
+ 
+@@ -606,13 +629,9 @@ unsigned int ElfFile<ElfFileParamNames>::findSection3(const SectionName & sectio
+ }
+ 
+ template<ElfFileParams>
+-bool ElfFile<ElfFileParamNames>::haveReplacedSection(const SectionName & sectionName)
++bool ElfFile<ElfFileParamNames>::haveReplacedSection(const SectionName & sectionName) const
+ {
+-    ReplacedSections::iterator i = replacedSections.find(sectionName);
+-
+-    if (i != replacedSections.end())
+-        return true;
+-    return false;
++    return (replacedSections.find(sectionName) != replacedSections.end());
+ }
+ 
+ template<ElfFileParams>
+@@ -625,7 +644,7 @@ std::string & ElfFile<ElfFileParamNames>::replaceSection(const SectionName & sec
+     if (i != replacedSections.end()) {
+         s = std::string(i->second);
+     } else {
+-        Elf_Shdr & shdr = findSection(sectionName);
++        auto shdr = findSection(sectionName);
+         s = std::string((char *) contents + rdi(shdr.sh_offset), rdi(shdr.sh_size));
+     }
+ 
+@@ -652,7 +671,8 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
+ 
+     for (auto & i : replacedSections) {
+         std::string sectionName = i.first;
+-        Elf_Shdr & shdr = findSection(sectionName);
++        auto & shdr = findSection(sectionName);
++        Elf_Shdr orig_shdr = shdr;
+         debug("rewriting section '%s' from offset 0x%x (size %d) to offset 0x%x (size %d)\n",
+             sectionName.c_str(), rdi(shdr.sh_offset), rdi(shdr.sh_size), curOff, i.second.size());
+ 
+@@ -687,6 +707,41 @@ void ElfFile<ElfFileParamNames>::writeReplacedSections(Elf_Off & curOff,
+                 }
+         }
+ 
++        /* If this is a note section, there might be a PT_NOTE segment that
++           must be sync'ed with it. Note that normalizeNoteSegments() will have
++           already taken care of PT_NOTE segments containing multiple note
++           sections. At this point, we can assume that the segment will map to
++           exactly one section.
++
++           Note sections also have particular alignment constraints: the
++           data inside the section is formatted differently depending on the
++           section alignment. Keep the original alignment if possible. */
++        if (rdi(shdr.sh_type) == SHT_NOTE) {
++            if (orig_shdr.sh_addralign < sectionAlignment)
++                shdr.sh_addralign = orig_shdr.sh_addralign;
++
++            for (unsigned int j = 0; j < phdrs.size(); ++j)
++                if (rdi(phdrs[j].p_type) == PT_NOTE) {
++                    Elf_Off p_start = rdi(phdrs[j].p_offset);
++                    Elf_Off p_end = p_start + rdi(phdrs[j].p_filesz);
++                    Elf_Off s_start = rdi(orig_shdr.sh_offset);
++                    Elf_Off s_end = s_start + rdi(orig_shdr.sh_size);
++
++                    /* Skip if no overlap. */
++                    if (!(s_start >= p_start && s_start < p_end) &&
++                        !(s_end > p_start && s_end <= p_end))
++                        continue;
++
++                    /* We only support exact matches. */
++                    if (p_start != s_start || p_end != s_end)
++                        error("unsupported overlap of SHT_NOTE and PT_NOTE");
++
++                    phdrs[j].p_offset = shdr.sh_offset;
++                    phdrs[j].p_vaddr = phdrs[j].p_paddr = shdr.sh_addr;
++                    phdrs[j].p_filesz = phdrs[j].p_memsz = shdr.sh_size;
++                }
++        }
++
+         curOff += roundUp(i.second.size(), sectionAlignment);
+     }
+ 
+@@ -709,13 +764,20 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+ 
+     debug("last page is 0x%llx\n", (unsigned long long) startPage);
+ 
++    /* When normalizing note segments we will in the worst case be adding
++       1 program header for each SHT_NOTE section. */
++    unsigned int num_notes = 0;
++    for (const auto & shdr : shdrs)
++        if (rdi(shdr.sh_type) == SHT_NOTE)
++            num_notes++;
++
+     /* Because we're adding a new section header, we're necessarily increasing
+        the size of the program header table.  This can cause the first section
+        to overlap the program header table in memory; we need to shift the first
+        few segments to someplace else. */
+     /* Some sections may already be replaced so account for that */
+     unsigned int i = 1;
+-    Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + 1)*sizeof(Elf_Phdr);
++    Elf_Addr pht_size = sizeof(Elf_Ehdr) + (phdrs.size() + num_notes + 1)*sizeof(Elf_Phdr);
+     while( shdrs[i].sh_addr <= pht_size && i < rdi(hdr->e_shnum) ) {
+         if (not haveReplacedSection(getSectionName(shdrs[i])))
+             replaceSection(getSectionName(shdrs[i]), shdrs[i].sh_size);
+@@ -737,7 +799,7 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+        ET_DYN as does LD when linking with pie. If we move PT_PHDR, it
+        has to stay in the first PT_LOAD segment or any subsequent ones
+        if they're continuous in memory due to linux kernel constraints
+-       (see BUGS). Since the end of the file would be after bss, we can't 
++       (see BUGS). Since the end of the file would be after bss, we can't
+        move PHDR there, we therefore choose to leave PT_PHDR where it is but
+        move enough following sections such that we can add the extra PT_LOAD
+        section to it. This PT_LOAD segment ensures the sections at the end of
+@@ -764,6 +826,9 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsLibrary()
+     wri(phdr.p_align, getPageSize());
+ 
+ 
++    normalizeNoteSegments();
++
++
+     /* Write out the replaced sections. */
+     Elf_Off curOff = startOffset;
+     writeReplacedSections(curOff, startPage, startOffset);
+@@ -851,6 +916,9 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
+     }
+ 
+ 
++    normalizeNoteSegments();
++
++
+     /* Compute the total space needed for the replaced sections, the
+        ELF header, and the program headers. */
+     size_t neededSpace = sizeof(Elf_Ehdr) + phdrs.size() * sizeof(Elf_Phdr);
+@@ -895,6 +963,67 @@ void ElfFile<ElfFileParamNames>::rewriteSectionsExecutable()
+ }
+ 
+ 
++template<ElfFileParams>
++void ElfFile<ElfFileParamNames>::normalizeNoteSegments()
++{
++    /* Break up PT_NOTE segments containing multiple SHT_NOTE sections. This
++       is to avoid having to deal with moving multiple sections together if
++       one of them has to be replaced. */
++
++    /* We don't need to do anything if no note segments were replaced. */
++    bool replaced_note = false;
++    for (const auto & i : replacedSections) {
++        if (rdi(findSection(i.first).sh_type) == SHT_NOTE)
++            replaced_note = true;
++    }
++    if (!replaced_note) return;
++
++    size_t orig_count = phdrs.size();
++    for (size_t i = 0; i < orig_count; ++i) {
++        auto & phdr = phdrs[i];
++        if (rdi(phdr.p_type) != PT_NOTE) continue;
++
++        size_t start_off = rdi(phdr.p_offset);
++        size_t curr_off = start_off;
++        size_t end_off = start_off + rdi(phdr.p_filesz);
++        while (curr_off < end_off) {
++            /* Find a section that starts at the current offset. If we can't
++               find one, it means the SHT_NOTE sections weren't contiguous
++               within the segment. */
++            size_t size = 0;
++            for (const auto & shdr : shdrs) {
++                if (rdi(shdr.sh_type) != SHT_NOTE) continue;
++                if (rdi(shdr.sh_offset) != curr_off) continue;
++                size = rdi(shdr.sh_size);
++                break;
++            }
++            if (size == 0)
++                error("cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections");
++            if (curr_off + size > end_off)
++                error("cannot normalize PT_NOTE segment: partially mapped SHT_NOTE section");
++
++            /* Build a new phdr for this note section. */
++            Elf_Phdr new_phdr = phdr;
++            wri(new_phdr.p_offset, curr_off);
++            wri(new_phdr.p_vaddr, rdi(phdr.p_vaddr) + (curr_off - start_off));
++            wri(new_phdr.p_paddr, rdi(phdr.p_paddr) + (curr_off - start_off));
++            wri(new_phdr.p_filesz, size);
++            wri(new_phdr.p_memsz, size);
++
++            /* If we haven't yet, reuse the existing phdr entry. Otherwise add
++               a new phdr to the table. */
++            if (curr_off == start_off)
++                phdr = new_phdr;
++            else
++                phdrs.push_back(new_phdr);
++
++            curr_off += size;
++        }
++    }
++    wri(hdr->e_phnum, phdrs.size());
++}
++
++
+ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::rewriteSections()
+ {
+@@ -947,7 +1076,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+     /* Update all those nasty virtual addresses in the .dynamic
+        section.  Note that not all executables have .dynamic sections
+        (e.g., those produced by klibc's klcc). */
+-    Elf_Shdr * shdrDynamic = findSection2(".dynamic");
++    auto shdrDynamic = findSection2(".dynamic");
+     if (shdrDynamic) {
+         Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic->sh_offset));
+         unsigned int d_tag;
+@@ -963,14 +1092,14 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+             else if (d_tag == DT_GNU_HASH)
+                 dyn->d_un.d_ptr = findSection(".gnu.hash").sh_addr;
+             else if (d_tag == DT_JMPREL) {
+-                Elf_Shdr * shdr = findSection2(".rel.plt");
++                auto shdr = findSection2(".rel.plt");
+                 if (!shdr) shdr = findSection2(".rela.plt"); /* 64-bit Linux, x86-64 */
+                 if (!shdr) shdr = findSection2(".rela.IA_64.pltoff"); /* 64-bit Linux, IA-64 */
+                 if (!shdr) error("cannot find section corresponding to DT_JMPREL");
+                 dyn->d_un.d_ptr = shdr->sh_addr;
+             }
+             else if (d_tag == DT_REL) { /* !!! hack! */
+-                Elf_Shdr * shdr = findSection2(".rel.dyn");
++                auto shdr = findSection2(".rel.dyn");
+                 /* no idea if this makes sense, but it was needed for some
+                    program */
+                 if (!shdr) shdr = findSection2(".rel.got");
+@@ -980,7 +1109,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+                 dyn->d_un.d_ptr = shdr->sh_addr;
+             }
+             else if (d_tag == DT_RELA) {
+-                Elf_Shdr * shdr = findSection2(".rela.dyn");
++                auto shdr = findSection2(".rela.dyn");
+                 /* some programs lack this section, but it doesn't seem to
+                    be a problem */
+                 if (!shdr) continue;
+@@ -1009,7 +1138,7 @@ void ElfFile<ElfFileParamNames>::rewriteHeaders(Elf_Addr phdrAddress)
+                 }
+                 std::string section = sectionsByOldIndex.at(shndx);
+                 assert(!section.empty());
+-                unsigned int newIndex = findSection3(section); // inefficient
++                auto newIndex = findSection3(section); // inefficient
+                 //debug("rewriting symbol %d: index = %d (%s) -> %d\n", entry, shndx, section.c_str(), newIndex);
+                 wri(sym->st_shndx, newIndex);
+                 /* Rewrite st_value.  FIXME: we should do this for all
+@@ -1033,7 +1162,7 @@ static void setSubstr(std::string & s, unsigned int pos, const std::string & t)
+ template<ElfFileParams>
+ std::string ElfFile<ElfFileParamNames>::getInterpreter()
+ {
+-    Elf_Shdr & shdr = findSection(".interp");
++    auto shdr = findSection(".interp");
+     return std::string((char *) contents + rdi(shdr.sh_offset), rdi(shdr.sh_size));
+ }
+ 
+@@ -1045,8 +1174,8 @@ void ElfFile<ElfFileParamNames>::modifySoname(sonameMode op, const std::string &
+         return;
+     }
+ 
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
++    auto shdrDynamic = findSection(".dynamic");
++    auto shdrDynStr = findSection(".dynstr");
+     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
+ 
+     /* Walk through the dynamic section, look for the DT_SONAME entry. */
+@@ -1130,11 +1259,11 @@ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
+     const std::vector<std::string> & allowedRpathPrefixes, std::string newRPath)
+ {
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
++    auto shdrDynamic = findSection(".dynamic");
+ 
+     /* !!! We assume that the virtual address in the DT_STRTAB entry
+        of the dynamic section corresponds to the .dynstr section. */
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
++    auto shdrDynStr = findSection(".dynstr");
+     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
+ 
+ 
+@@ -1252,14 +1381,18 @@ void ElfFile<ElfFileParamNames>::modifyRPath(RPathOp op,
+ 
+ 
+     if (!forceRPath && dynRPath && !dynRunPath) { /* convert DT_RPATH to DT_RUNPATH */
+-        dynRPath->d_tag = DT_RUNPATH;
++        wri(dynRPath->d_tag, DT_RUNPATH);
+         dynRunPath = dynRPath;
+         dynRPath = 0;
++        changed = true;
+     } else if (forceRPath && dynRunPath) { /* convert DT_RUNPATH to DT_RPATH */
+-        dynRunPath->d_tag = DT_RPATH;
++        wri(dynRunPath->d_tag, DT_RPATH);
+         dynRPath = dynRunPath;
+         dynRunPath = 0;
+-    } else if (std::string(rpath ? rpath : "") == newRPath) {
++        changed = true;
++    }
++
++    if (std::string(rpath ? rpath : "") == newRPath) {
+         return;
+     }
+ 
+@@ -1322,8 +1455,8 @@ void ElfFile<ElfFileParamNames>::removeNeeded(const std::set<std::string> & libs
+ {
+     if (libs.empty()) return;
+ 
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
++    auto shdrDynamic = findSection(".dynamic");
++    auto shdrDynStr = findSection(".dynstr");
+     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
+ 
+     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
+@@ -1350,8 +1483,8 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
+ {
+     if (libs.empty()) return;
+ 
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
++    auto shdrDynamic = findSection(".dynamic");
++    auto shdrDynStr = findSection(".dynstr");
+     char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
+ 
+     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
+@@ -1396,7 +1529,7 @@ void ElfFile<ElfFileParamNames>::replaceNeeded(const std::map<std::string, std::
+     // be replaced.
+ 
+     if (verNeedNum) {
+-        Elf_Shdr & shdrVersionR = findSection(".gnu.version_r");
++        auto shdrVersionR = findSection(".gnu.version_r");
+         // The filename strings in the .gnu.version_r are different from the
+         // ones in .dynamic: instead of being in .dynstr, they're in some
+         // arbitrary section and we have to look in ->sh_link to figure out
+@@ -1446,8 +1579,8 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
+ {
+     if (libs.empty()) return;
+ 
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
++    auto shdrDynamic = findSection(".dynamic");
++    auto shdrDynStr = findSection(".dynstr");
+ 
+     /* add all new libs to the dynstr string table */
+     unsigned int length = 0;
+@@ -1489,17 +1622,17 @@ void ElfFile<ElfFileParamNames>::addNeeded(const std::set<std::string> & libs)
+ }
+ 
+ template<ElfFileParams>
+-void ElfFile<ElfFileParamNames>::printNeededLibs()
++void ElfFile<ElfFileParamNames>::printNeededLibs() // const
+ {
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
+-    Elf_Shdr & shdrDynStr = findSection(".dynstr");
+-    char *strTab = (char *)contents + rdi(shdrDynStr.sh_offset);
++    const auto shdrDynamic = findSection(".dynamic");
++    const auto shdrDynStr = findSection(".dynstr");
++    const char *strTab = (char *)contents + rdi(shdrDynStr.sh_offset);
+ 
+-    Elf_Dyn *dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
++    const Elf_Dyn *dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
+ 
+     for (; rdi(dyn->d_tag) != DT_NULL; dyn++) {
+         if (rdi(dyn->d_tag) == DT_NEEDED) {
+-            char *name = strTab + rdi(dyn->d_un.d_val);
++            const char *name = strTab + rdi(dyn->d_un.d_val);
+             printf("%s\n", name);
+         }
+     }
+@@ -1509,7 +1642,7 @@ void ElfFile<ElfFileParamNames>::printNeededLibs()
+ template<ElfFileParams>
+ void ElfFile<ElfFileParamNames>::noDefaultLib()
+ {
+-    Elf_Shdr & shdrDynamic = findSection(".dynamic");
++    auto shdrDynamic = findSection(".dynamic");
+ 
+     Elf_Dyn * dyn = (Elf_Dyn *) (contents + rdi(shdrDynamic.sh_offset));
+     Elf_Dyn * dynFlags1 = 0;
+@@ -1545,6 +1678,33 @@ void ElfFile<ElfFileParamNames>::noDefaultLib()
+     changed = true;
+ }
+ 
++template<ElfFileParams>
++void ElfFile<ElfFileParamNames>::clearSymbolVersions(const std::set<std::string> & syms)
++{
++    if (syms.empty()) return;
++
++    auto shdrDynStr = findSection(".dynstr");
++    auto shdrDynsym = findSection(".dynsym");
++    auto shdrVersym = findSection(".gnu.version");
++
++    char * strTab = (char *) contents + rdi(shdrDynStr.sh_offset);
++    Elf_Sym * dynsyms = (Elf_Sym *) (contents + rdi(shdrDynsym.sh_offset));
++    Elf_Versym * versyms = (Elf_Versym *) (contents + rdi(shdrVersym.sh_offset));
++    size_t count = rdi(shdrDynsym.sh_size) / sizeof(Elf_Sym);
++
++    if (count != rdi(shdrVersym.sh_size) / sizeof(Elf_Versym))
++        error("versym size mismatch");
++
++    for (size_t i = 0; i < count; i++) {
++        auto dynsym = dynsyms[i];
++        auto name = strTab + rdi(dynsym.st_name);
++        if (syms.find(name) != syms.end()) {
++            debug("clearing symbol version for %s\n", name);
++            wri(versyms[i], 1);
++        }
++    }
++    changed = true;
++}
+ 
+ static bool printInterpreter = false;
+ static bool printSoname = false;
+@@ -1560,6 +1720,7 @@ static std::string newRPath;
+ static std::set<std::string> neededLibsToRemove;
+ static std::map<std::string, std::string> neededLibsToReplace;
+ static std::set<std::string> neededLibsToAdd;
++static std::set<std::string> symbolsToClearVersion;
+ static bool printNeeded = false;
+ static bool noDefaultLib = false;
+ 
+@@ -1593,6 +1754,7 @@ static void patchElf2(ElfFile && elfFile, const FileContents & fileContents, std
+     elfFile.removeNeeded(neededLibsToRemove);
+     elfFile.replaceNeeded(neededLibsToReplace);
+     elfFile.addNeeded(neededLibsToAdd);
++    elfFile.clearSymbolVersions(symbolsToClearVersion);
+ 
+     if (noDefaultLib)
+         elfFile.noDefaultLib();
+@@ -1613,15 +1775,13 @@ static void patchElf()
+         if (!printInterpreter && !printRPath && !printSoname && !printNeeded)
+             debug("patching ELF file '%s'\n", fileName.c_str());
+ 
+-        debug("Kernel page size is %u bytes\n", getPageSize());
+-
+         auto fileContents = readFile(fileName);
+         std::string outputFileName2 = outputFileName.empty() ? fileName : outputFileName;
+ 
+         if (getElfType(fileContents).is32Bit)
+-            patchElf2(ElfFile<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Addr, Elf32_Off, Elf32_Dyn, Elf32_Sym, Elf32_Verneed>(fileContents), fileContents, outputFileName2);
++            patchElf2(ElfFile<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr, Elf32_Addr, Elf32_Off, Elf32_Dyn, Elf32_Sym, Elf32_Verneed, Elf32_Versym>(fileContents), fileContents, outputFileName2);
+         else
+-            patchElf2(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Addr, Elf64_Off, Elf64_Dyn, Elf64_Sym, Elf64_Verneed>(fileContents), fileContents, outputFileName2);
++            patchElf2(ElfFile<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr, Elf64_Addr, Elf64_Off, Elf64_Dyn, Elf64_Sym, Elf64_Verneed, Elf64_Versym>(fileContents), fileContents, outputFileName2);
+     }
+ }
+ 
+@@ -1645,6 +1805,7 @@ void showHelp(const std::string & progName)
+   [--replace-needed LIBRARY NEW_LIBRARY]\n\
+   [--print-needed]\n\
+   [--no-default-lib]\n\
++  [--clear-symbol-version SYMBOL]\n\
+   [--output FILE]\n\
+   [--debug]\n\
+   [--version]\n\
+@@ -1670,8 +1831,8 @@ int mainWrapped(int argc, char * * argv)
+         }
+         else if (arg == "--page-size") {
+             if (++i == argc) error("missing argument");
+-            pageSize = atoi(argv[i]);
+-            if (pageSize <= 0) error("invalid argument to --page-size");
++            forcedPageSize = atoi(argv[i]);
++            if (forcedPageSize <= 0) error("invalid argument to --page-size");
+         }
+         else if (arg == "--print-interpreter") {
+             printInterpreter = true;
+@@ -1732,6 +1893,10 @@ int mainWrapped(int argc, char * * argv)
+             neededLibsToReplace[ argv[i+1] ] = argv[i+2];
+             i += 2;
+         }
++        else if (arg == "--clear-symbol-version") {
++            if (++i == argc) error("missing argument");
++            symbolsToClearVersion.insert(argv[i]);
++        }
+         else if (arg == "--output") {
+             if (++i == argc) error("missing argument");
+             outputFileName = argv[i];
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 96339b3..dbb7580 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -23,7 +23,9 @@ src_TESTS = \
+   set-interpreter-long.sh set-rpath.sh no-rpath.sh big-dynstr.sh \
+   set-rpath-library.sh soname.sh shrink-rpath-with-allowed-prefixes.sh \
+   force-rpath.sh \
+-  output-flag.sh
++  plain-needed.sh \
++  output-flag.sh \
++  build-id.sh
+ 
+ build_TESTS = \
+   $(no_rpath_arch_TESTS)
+@@ -75,7 +77,10 @@ big_dynstr_LDFLAGS = $(LDFLAGS_local)
+ # - without libtool, only archives (static libraries) can be built by automake
+ # - with libtool, it is difficult to control options
+ # - with libtool, it is not possible to compile convenience *dynamic* libraries :-(
+-check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so
++check_PROGRAMS += libfoo.so libfoo-scoped.so libbar.so libbar-scoped.so libsimple.so libbuildid.so
++
++libbuildid_so_SOURCES = simple.c
++libbuildid_so_LDFLAGS = $(LDFLAGS_sharedlib) -Wl,-build-id
+ 
+ libfoo_so_SOURCES = foo.c
+ libfoo_so_LDADD = -lbar $(AM_LDADD)
+diff --git a/tests/build-id.sh b/tests/build-id.sh
+new file mode 100755
+index 0000000..45a6c4d
+--- /dev/null
++++ b/tests/build-id.sh
+@@ -0,0 +1,19 @@
++#! /bin/sh -e
++SCRATCH=scratch/$(basename $0 .sh)
++
++if ! command -v readelf >/dev/null; then
++    echo "No readelf found; skip test"
++    exit 0
++fi
++
++rm -rf "${SCRATCH}"
++mkdir -p "${SCRATCH}"
++
++cp libbuildid.so "${SCRATCH}/"
++
++long_rpath="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
++
++../src/patchelf \
++  --set-rpath "$long_rpath" "${SCRATCH}/libbuildid.so"
++
++readelf -n "${SCRATCH}/libbuildid.so" | grep -q "Build ID"
+diff --git a/tests/no-rpath-prebuild.sh b/tests/no-rpath-prebuild.sh
+index aa27b7a..c58cf8e 100755
+--- a/tests/no-rpath-prebuild.sh
++++ b/tests/no-rpath-prebuild.sh
+@@ -4,7 +4,7 @@ ARCH="$1"
+ PAGESIZE=4096
+ 
+ if [ -z "$ARCH" ]; then
+-  ARCH=$(basename $0 .sh | sed -e 's/.*-//')
++  ARCH=$(basename $0 .sh | sed -e 's/^no-rpath-//')
+ fi
+ 
+ SCRATCH=scratch/no-rpath-$ARCH
+diff --git a/tests/plain-needed.sh b/tests/plain-needed.sh
+new file mode 100755
+index 0000000..36267fb
+--- /dev/null
++++ b/tests/plain-needed.sh
+@@ -0,0 +1,4 @@
++#! /bin/sh
++set -e
++echo "Confirming main requires libfoo"
++../src/patchelf --print-needed main | grep -q libfoo.so
+-- 
+2.23.3
+


### PR DESCRIPTION
Bug reports for Manylinux2014_aarch64 wheels show that they contain bad alignment for Arm distros that use 64k pagesize.  This updates patchelf 0.11 to include recent patches that force Arm64 page alignment to 64k regardless of the base system used for building.

Solves Issue: https://github.com/pypa/manylinux/issues/735