### PR TITLE
manylinux2010: Use CentOS Vault repos

### DIFF
--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -12,6 +12,13 @@ ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib64/dyninst:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to http://vault.centos.org
+# From: https://github.com/rust-lang/rust/pull/41045
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf &&  \
+    sed -i 's/mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo && \
+    sed -i 's/#\(baseurl.*\)mirror.centos.org/\1vault.centos.org/' /etc/yum.repos.d/*.repo
+
 COPY build_scripts /build_scripts
 RUN bash build_scripts/build.sh && rm -r build_scripts
 

--- a/docker/glibc/Dockerfile
+++ b/docker/glibc/Dockerfile
@@ -26,6 +26,13 @@ COPY --from=quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest \
     /rpms/nscd-2.12-1.212.1.el6.x86_64.rpm \
     /rpms/
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to http://vault.centos.org
+# From: https://github.com/rust-lang/rust/pull/41045
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf &&  \
+    sed -i 's/mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo && \
+    sed -i 's/#\(baseurl.*\)mirror.centos.org/\1vault.centos.org/' /etc/yum.repos.d/*.repo
+
 RUN yum install -y glibc.i686 glibc-devel.i686 glibc-static.i686 glibc.x86_64 glibc-devel.x86_64 glibc-static.x86_64 && \
     yum -y install /rpms/* && rm -rf /rpms && yum -y clean all && rm -rf /var/cache/yum/* && \
     # if we updated glibc, we need to strip locales again...

--- a/docker/glibc/Dockerfile-i686
+++ b/docker/glibc/Dockerfile-i686
@@ -1,5 +1,12 @@
 FROM i386/centos:6
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to http://vault.centos.org
+# From: https://github.com/rust-lang/rust/pull/41045
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf &&  \
+    sed -i 's/mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo && \
+    sed -i 's/#\(baseurl.*\)mirror.centos.org/\1vault.centos.org/' /etc/yum.repos.d/*.repo
+
 RUN echo "i386" > /etc/yum/vars/basearch
 RUN yum -y update && \
     yum install -y util-linux-ng


### PR DESCRIPTION
As CentOS 6 is EOL, the original repositories are not working anymore.
Switch to the Vault repos which hosts snapshots of older trees.

Closes: #836 