### PR TITLE
[manylinux2010 ] Use https://vault.centos.org for yum repos

### DIFF
--- a/docker/Dockerfile-i686
+++ b/docker/Dockerfile-i686
@@ -11,6 +11,12 @@ ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 # Set a base architecture of yum package to i386
 RUN echo "i386" > /etc/yum/vars/basearch
 

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -12,6 +12,12 @@ ENV PATH $DEVTOOLSET_ROOTPATH/usr/bin:$PATH
 ENV LD_LIBRARY_PATH $DEVTOOLSET_ROOTPATH/usr/lib64:$DEVTOOLSET_ROOTPATH/usr/lib:$DEVTOOLSET_ROOTPATH/usr/lib64/dyninst:$DEVTOOLSET_ROOTPATH/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 COPY build_scripts /build_scripts
 RUN bash build_scripts/build.sh && rm -r build_scripts
 

--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -58,6 +58,8 @@ case $AUDITWHEEL_ARCH in
 x86_64)
   # Install centos-release-scl to get devtoolset-8
   yum -y install centos-release-scl
+  sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+  sed -i 's;^#.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
   ;;
 i686)
   # Add libgfortran4 for devtoolset-7 compat

--- a/docker/glibc/Dockerfile
+++ b/docker/glibc/Dockerfile
@@ -26,6 +26,12 @@ COPY --from=quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest \
     /rpms/nscd-2.12-1.212.1.el6.x86_64.rpm \
     /rpms/
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 RUN yum install -y glibc.i686 glibc-devel.i686 glibc-static.i686 glibc.x86_64 glibc-devel.x86_64 glibc-static.x86_64 && \
     yum -y install /rpms/* && rm -rf /rpms && yum -y clean all && rm -rf /var/cache/yum/* && \
     # if we updated glibc, we need to strip locales again...

--- a/docker/glibc/Dockerfile-i686
+++ b/docker/glibc/Dockerfile-i686
@@ -1,5 +1,12 @@
 FROM i386/centos:6
 
+
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 RUN echo "i386" > /etc/yum/vars/basearch
 RUN yum -y update && \
     yum install -y util-linux-ng

--- a/docker/glibc/Dockerfile-x86_64
+++ b/docker/glibc/Dockerfile-x86_64
@@ -1,4 +1,10 @@
 FROM centos:6
 
+# Centos 6 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf && \
+    sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
+    sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+
 COPY ./build_scripts /build_scripts
 RUN bash /build_scripts/rebuild-glibc-without-vsyscall.sh

--- a/docker/glibc/build_scripts/CentOS-source.repo
+++ b/docker/glibc/build_scripts/CentOS-source.repo
@@ -1,6 +1,6 @@
 [base-source]
 name=CentOS-6.10 - Base SRPMS
-baseurl=http://vault.centos.org/6.10/os/Source/
+baseurl=https://vault.centos.org/6.10/os/Source/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 priority=1


### PR DESCRIPTION
Centos 6 is EOL and is no longer available from the usual mirrors, so switch
to https://vault.centos.org

Fix #836