### PR TITLE
Request http mirrors for yum EPEL repos on manylinux1

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -54,6 +54,7 @@ mv devtools-2.repo /etc/yum.repos.d/devtools-2.repo
 sed -i 's/\<http\>/https/g' /etc/yum.repos.d/devtools-2.repo
 rpm -Uvh --replacepkgs epel-release-5*.rpm
 rm -f epel-release-5*.rpm
+sed -i 's/\(mirrorlist=.*\)/\1\&protocol=http/g' /etc/yum.repos.d/epel*.repo
 
 # from now on, we shall only use curl to retrieve files
 yum -y erase wget


### PR DESCRIPTION
OpenSSL on CentOS 5 is old enough that it is starting to break when accessing HTTPS sites. This change updates the yum EPEL repos' `mirrorlist` to only request HTTP mirrors instead of using whatever is returned by default which is starting to cause transient failures when using yum:

```
# curl http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=x86_64
# repo = epel-5 arch = x86_64 country = US 
http://mirror.math.princeton.edu/pub/fedora-archive/epel/5/x86_64/
http://pubmirror1.math.uh.edu/fedora-buffet/archive/epel/5/x86_64/
https://d2lzkl7pfhq30w.cloudfront.net/pub/archive/epel/5/x86_64/
http://mirrors.kernel.org/fedora-buffet/archive/epel/5/x86_64/
https://pubmirror2.math.uh.edu/fedora-buffet/archive/epel/5/x86_64/
https://dl.fedoraproject.org/pub/archive/epel/5/x86_64/

# openssl s_client -connect dl.fedoraproject.org:443
CONNECTED(00000003)
12:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:s23_clnt.c:586:
```