### PR TITLE
[manylinux2010] glibc update & glibc cache/image size reduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       script:
         - PLATFORM=$PLATFORM docker/glibc/build.sh all
       before_cache:
-        - travis-ci/cache_images.sh combined
+        - travis-ci/cache_images.sh combined_build
     - <<: *manylinux-build
       env:
         - PLATFORM="x86_64"

--- a/docker/glibc/Dockerfile
+++ b/docker/glibc/Dockerfile
@@ -3,27 +3,27 @@ LABEL maintainer="The Manylinux project"
 
 # do not install debuginfo and what x86_64 already provides
 COPY --from=quay.io/pypa/manylinux2010_centos-6-with-vsyscall32:latest \
-    /rpms/glibc-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/glibc-common-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/glibc-debuginfo-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/glibc-debuginfo-common-2.12-1.212.1.el6.i686.rpm \
-    /rpms/glibc-devel-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/glibc-headers-2.12-1.212.1.el6.i686.rpm \
-    /rpms/glibc-static-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/glibc-utils-2.12-1.212.1.el6.i686.rpm \
-    #/rpms/nscd-2.12-1.212.1.el6.i686.rpm \
+    /rpms/glibc-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/glibc-common-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/glibc-debuginfo-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/glibc-debuginfo-common-2.12-1.212.1.el6_10.3.i686.rpm \
+    /rpms/glibc-devel-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/glibc-headers-2.12-1.212.1.el6_10.3.i686.rpm \
+    /rpms/glibc-static-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/glibc-utils-2.12-1.212.1.el6_10.3.i686.rpm \
+    #/rpms/nscd-2.12-1.212.1.el6_10.3.i686.rpm \
     /rpms/
 # do not install debuginfo
 COPY --from=quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest \
-    /rpms/glibc-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/glibc-common-2.12-1.212.1.el6.x86_64.rpm \
-    #/rpms/glibc-debuginfo-2.12-1.212.1.el6.x86_64.rpm \
-    #/rpms/glibc-debuginfo-common-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/glibc-devel-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/glibc-headers-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/glibc-static-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/glibc-utils-2.12-1.212.1.el6.x86_64.rpm \
-    /rpms/nscd-2.12-1.212.1.el6.x86_64.rpm \
+    /rpms/glibc-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/glibc-common-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    #/rpms/glibc-debuginfo-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    #/rpms/glibc-debuginfo-common-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/glibc-devel-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/glibc-headers-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/glibc-static-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/glibc-utils-2.12-1.212.1.el6_10.3.x86_64.rpm \
+    /rpms/nscd-2.12-1.212.1.el6_10.3.x86_64.rpm \
     /rpms/
 
 # Centos 6 is EOL and is no longer available from the usual mirrors, so switch

--- a/docker/glibc/Dockerfile
+++ b/docker/glibc/Dockerfile
@@ -1,5 +1,4 @@
-FROM centos:6
-LABEL maintainer="The Manylinux project"
+FROM centos:6 AS manylinux2010_centos-6-no-vsyscall-build
 
 # do not install debuginfo and what x86_64 already provides
 COPY --from=quay.io/pypa/manylinux2010_centos-6-with-vsyscall32:latest \
@@ -32,10 +31,22 @@ RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf &&
     sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo && \
     sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
 
-RUN yum install -y glibc.i686 glibc-devel.i686 glibc-static.i686 glibc.x86_64 glibc-devel.x86_64 glibc-static.x86_64 && \
-    yum -y install /rpms/* && rm -rf /rpms && yum -y clean all && rm -rf /var/cache/yum/* && \
+RUN yum update -y && \
+    yum install -y glibc.i686 glibc-devel.i686 glibc-static.i686 glibc.x86_64 glibc-devel.x86_64 glibc-static.x86_64 && \
+    yum -y install /rpms/* && rm -rf /rpms && rpm --rebuilddb && yum -y clean all && rm -rf /var/cache/yum/* && \
     # if we updated glibc, we need to strip locales again...
     localedef --list-archive | grep -v -i ^en_US.utf8 | xargs localedef --delete-from-archive && \
     mv -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl && \
     build-locale-archive && \
-    find /usr/share/locale -mindepth 1 -maxdepth 1 -not \( -name 'en*' -or -name 'locale.alias' \) | xargs rm -rf
+    find /usr/share/locale -mindepth 1 -maxdepth 1 -not \( -name 'en*' -or -name 'locale.alias' \) | xargs rm -rf && \
+    rm -rf /root/* /tmp/* /var/log/*
+
+RUN ln -sf cracklib-small.pwi /usr/share/cracklib/pw_dict.pwi && \
+    ln -sf cracklib-small.pwd /usr/share/cracklib/pw_dict.pwd && \
+    rm -rf /var/lib/yum/history/* && \
+    find /usr/lib64/python2.6 \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -delete
+
+FROM scratch
+LABEL maintainer="The Manylinux project"
+COPY --from=manylinux2010_centos-6-no-vsyscall-build / /
+CMD ["/bin/bash"]

--- a/docker/glibc/Dockerfile-i686
+++ b/docker/glibc/Dockerfile-i686
@@ -8,7 +8,8 @@ RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf &&
     sed -i 's;^#baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
 
 RUN echo "i386" > /etc/yum/vars/basearch
-RUN yum -y update && \
-    yum install -y util-linux-ng
+RUN yum install -y util-linux-ng && \
+    yum -y clean all && \
+    rm -rf /var/cache/yum/*
 COPY ./build_scripts /build_scripts
 RUN linux32 bash /build_scripts/rebuild-glibc-without-vsyscall.sh

--- a/docker/glibc/build.sh
+++ b/docker/glibc/build.sh
@@ -31,9 +31,14 @@ case "${1-}" in
     ;;
 all)
     docker_build \
-        -t quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest \
+        --target manylinux2010_centos-6-no-vsyscall-build \
+        -t quay.io/pypa/manylinux2010_centos-6-no-vsyscall-build:latest \
         --cache-from quay.io/pypa/manylinux2010_centos-6-with-vsyscall32:latest \
         --cache-from quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest \
+        --cache-from quay.io/pypa/manylinux2010_centos-6-no-vsyscall-build:latest
+    docker_build \
+        -t quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest \
+        --cache-from quay.io/pypa/manylinux2010_centos-6-no-vsyscall-build:latest \
         --cache-from quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest
     ;;
 *)

--- a/docker/glibc/build_scripts/CentOS-source.repo
+++ b/docker/glibc/build_scripts/CentOS-source.repo
@@ -1,6 +1,14 @@
-[base-source]
-name=CentOS-6.10 - Base SRPMS
+[os-source]
+name=CentOS-6.10 - OS SRPMS
 baseurl=https://vault.centos.org/6.10/os/Source/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+priority=1
+enabled=1
+
+[updates-source]
+name=CentOS-6.10 - Updates SRPMS
+baseurl=https://vault.centos.org/6.10/updates/Source/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 priority=1

--- a/docker/glibc/build_scripts/glibc.spec.patch
+++ b/docker/glibc/build_scripts/glibc.spec.patch
@@ -5,25 +5,25 @@ index 9bd07c9..c389711 100644
 @@ -1,6 +1,6 @@
  %define glibcsrcdir glibc-2.12-2-gc4ccff1
  %define glibcversion 2.12
--%define glibcrelease 1.212%{?dist}
-+%define glibcrelease 1.212.1%{?dist}
+-%define glibcrelease 1.212%{?dist}.3
++%define glibcrelease 1.212.1%{?dist}.3
  %define run_glibc_tests 1
  %define auxarches athlon sparcv9v sparc64v alphaev6
  %define xenarches i686 athlon
-@@ -279,6 +279,7 @@ 
- Patch247: glibc-rh1452717-4.patch
- Patch248: glibc-rh1504810-1.patch
- Patch249: glibc-rh1504810-2.patch
-+Patch250: remove-vsyscall.patch
- 
+@@ -283,6 +283,7 @@
+ Patch251: glibc-rh1555930-1.patch
+ Patch252: glibc-rh1555930-2.patch
+ Patch253: glibc-rh1577437.patch
++Patch254: remove-vsyscall.patch
+
  Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
  Obsoletes: glibc-profile < 2.4
-@@ -731,6 +732,7 @@
- %patch247 -p1
- %patch248 -p1
- %patch249 -p1
-+%patch250 -E -p3
- 
+@@ -739,6 +739,7 @@
+ %patch251 -p1
+ %patch252 -p1
+ %patch253 -p1
++%patch254 -E -p3
+
  # A lot of programs still misuse memcpy when they have to use
  # memmove. The memcpy implementation below is not tolerant at
 

--- a/docker/glibc/build_scripts/rebuild-glibc-without-vsyscall.sh
+++ b/docker/glibc/build_scripts/rebuild-glibc-without-vsyscall.sh
@@ -31,7 +31,7 @@ mkdir $DOWNLOADED_SRPMS
 adduser mockbuild
 # yumdownloader assumes the current working directory
 (cd $DOWNLOADED_SRPMS && yumdownloader --source glibc)
-rpm -ivh $DOWNLOADED_SRPMS/glibc-$ORIGINAL_GLIBC_VERSION.el6.src.rpm
+rpm -ivh $DOWNLOADED_SRPMS/glibc-$ORIGINAL_GLIBC_VERSION.el6_10.3.src.rpm
 # Prepare the source by applying Red Hat and CentOS patches
 rpmbuild -bp $SRPM_TOPDIR/SPECS/glibc.spec
 
@@ -39,6 +39,9 @@ rpmbuild -bp $SRPM_TOPDIR/SPECS/glibc.spec
 cp $MY_DIR/remove-vsyscall.patch $SRPM_TOPDIR/SOURCES
 # Patch the RPM spec file so that it uses the vsyscall removal patch
 (cd $SRPM_TOPDIR/SPECS && patch -p2 < $MY_DIR/glibc.spec.patch)
+
+# Use dist .el6_10 to mimic replaced glibc
+sed -i 's/.el6$/.el6_10/g' /etc/rpm/macros.dist
 
 # Build the RPMS
 # In case of error, you can `docker commit` to inspect the build.log

--- a/docker/glibc/build_scripts/rebuild-glibc-without-vsyscall.sh
+++ b/docker/glibc/build_scripts/rebuild-glibc-without-vsyscall.sh
@@ -52,4 +52,7 @@ mv $SRPM_TOPDIR/RPMS/* /rpms/
 # Show us what happened last before cleaning up the log
 echo ~~~~~~~~~~~~~~~~~~~~~ final lines of the build log ~~~~~~~~~~~~~~~~~~~~~ >/dev/null
 tail -n30 /var/log/build.log
-rm /var/log/build.log
+
+# We don't need to keep anything execept /rpms/*
+rm -rf /root /tmp /var /sbin
+rm -rf /usr /lib*

--- a/travis-ci/tags.sh
+++ b/travis-ci/tags.sh
@@ -5,6 +5,12 @@ case "${1-}" in
 64)
     tags=( quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest )
     ;;
+combined_build)
+    tags=(
+        quay.io/pypa/manylinux2010_centos-6-no-vsyscall-build:latest
+        quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest
+    )
+    ;;
 combined)
     tags=( quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest )
     ;;
@@ -12,11 +18,12 @@ all)
     tags=(
         quay.io/pypa/manylinux2010_centos-6-with-vsyscall32:latest
         quay.io/pypa/manylinux2010_centos-6-with-vsyscall64:latest
+        quay.io/pypa/manylinux2010_centos-6-no-vsyscall-build:latest
         quay.io/pypa/manylinux2010_centos-6-no-vsyscall:latest
     )
     ;;
 *)
-    echo "Usage: $0 {32|64|combined|all}" >&2
+    echo "Usage: $0 {32|64|combined_build|combined|all}" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
- Update glibc from 2.12-1.212.el6 to 2.12-1.212.el6_10.3
Latest (and last) update to get security fixes for the rebuilt glibc

- Reduce glibc rebuild cache size
2.5GB -> 1GB, should save resources on both local builds and travis-ci builds

- Reduce image size
Final image is now built from scratch because almost everything gets replaced in the base centos:6 image which means it's useless to pull this base image as it will not help with caching but just increase storage/bandwidth requirements when the host does not use centos:6 base image for other images => 384 MB (including centos:6, 194MB) -> 200MB