### PR TITLE
Build arm64 & s390x on travis-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,7 @@ jobs:
           - policy: "manylinux2014"
             platform: "x86_64"
           - policy: "manylinux2014"
-            platform: "aarch64"
-          - policy: "manylinux2014"
             platform: "ppc64le"
-          - policy: "manylinux2014"
-            platform: "s390x"
 
     env:
       POLICY: ${{ matrix.policy }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: c
+os: linux
+dist: focal
+services:
+  - docker
+
+# Don't build the depandabot branches that dependabot creates; it's redundant
+# with the PR builds that Travis also does.
+branches:
+  except:
+    - /^dependabot/
+
+cache:
+  directories:
+    - ${HOME}/buildx-cache/
+
+env:
+  global:
+    # QUAY_USERNAME and QUAY_PASSWORD for docker image upload
+    - secure: "lKaTzEL6UNiEfp+BWLOUILG9BMtjwEMpwt6Yag0cQGHix7qJ/ElZ0t3oFw6ZwuDmA5qceAXIdxHLUK9HGVI2MloLk8czGhjvtfJ4XhOxtEJRQ0VkDGPsKN4cfhB4ZjGo6GAPtNqStMyNiY7BZuTrZa7coDLCoUeYcOmTpi6pmd1rrkk725B9QCTuhFHbPhkuL2yu/Jk6WxkHJBKjmuZek+iQa7lRItgMrG0/319PXLvwIGGl00nLFy+Ly5Ciwzux4wuHLTySZQKu0H9FX81A7smM0FW/42kg3ckGa2qLxRw/Pi8Nm/aIk8LD0QXzI5N7HhFfidOTgDS8Mt1HgfxmTk4wUXZ/KvCCshqjimzMc/s9i9wPZX9UqqcfrpZkmwz8dzhm1bndN45ZOCy6xAYT6dzf8T4mLMDjVWSW4+DUoW4sYHRLVujjcMk7ybcwGV43VruPTJnc8XVAhT+VIMQkoPjhQmTOn8h82LRNGYtLa5RReCh9OPKVYB2Quz18FXMWgFt7A6VWudL0c7/8CusLvuo+pLcxt9pnV40rvu1YEohpEj8qR/qTSaDUBZM0J9SVf5zrZR80pZUnXkDF8nm+mcLOTley3YWipU19lCR7dzVyCAiQdVAuNPdnyem3Yk8enGkAJbfLd6eaIDs+p73D0JXh1Nx1px1movVLQH3ohIw="
+    - secure: "w1614pomHLltkBhqWM2bOvbymFWIWKqSqqIBDvaNn9tbQScioItJoELBT7g7+cD7nyU7OvpQ1U2fk0xVkCeNvYU0xS1vP4o/VnZRpup7f7Tkiq+2rf4fjwYr3HHnJjwak1l9bsw6FkgzKaVvSdiUJHMVxiIuLd3fVozR7qjBBhTDxSlWGOpSgd+ttpgMZwU5zQjdaVQr1D7E8M0979ZnWMrNRyLiAUeHaPILS815b+ijgqR+i5nmu0/FTCGM9Ik4KIzIfWq8AdfPdbRiq8c+LrrTPfyKcIQJaHmfduYRM4LycGWwzkXFBNtLrJ7uFLG9RDVemOHuHOWIJX8qCUIV4XuESXxH3fUQr6r+yxquTJbzXxNtoaLa6tBOTQWKDrRjT4z9Mf9Im14F2V59EUDoQowHx5bjunOH5wg3ruYNKYYBFRYra5kx0CkKrqFBzyl8fTUEQLyx1HWTVUC1WTXEeD/aFKOSIxW5DxZr5W4LLlW2+Raa52ZzY28Q6AdueFQCRzoJ70/GsJRlSsBdWNOHN4gSp1cZuToLWY15y64QhAMVDpikB+V4hmkbceLiTqeWzTStNL1sa32RHr6i/9zeFZw1pMD1+eOg9x6fgODfh2sqr/zPbu2oONsHnc4D2jwsEax4o+Dv5QHLvK7jdyWUmu47a9QReoexXK60jZXs3CA="
+
+jobs:
+   include:
+    - arch: arm64-graviton2
+      virt: vm
+      group: edge
+      env: POLICY="manylinux2014" PLATFORM="aarch64"
+    #- arch: ppc64le
+    #  env: POLICY="manylinux2014" PLATFORM="ppc64le"
+    - arch: s390x
+      env: POLICY="manylinux2014" PLATFORM="s390x"
+
+before_install:
+  - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi
+
+install:
+  - ./travisci-install-buildx.sh
+
+script:
+  - COMMIT_SHA=${TRAVIS_COMMIT} ./build.sh
+
+before_cache:
+  - cp -rlf ./.buildx-cache-* ${HOME}/buildx-cache/
+
+deploy:
+  provider: script
+  script: COMMIT_SHA=${TRAVIS_COMMIT} ./deploy.sh
+  on:
+    branch: master
+    repo: pypa/manylinux

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script is used to install docker buildx in travis-ci
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+BUILDX_MACHINE=$(uname -m)
+if [ ${BUILDX_MACHINE} == "x86_64" ]; then
+	BUILDX_MACHINE=amd64
+elif [ ${BUILDX_MACHINE} == "aarch64" ]; then
+	BUILDX_MACHINE=arm64
+fi
+
+mkdir -vp ~/.docker/cli-plugins/
+curl -sSL "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-${BUILDX_MACHINE}" > ~/.docker/cli-plugins/docker-buildx
+chmod a+x ~/.docker/cli-plugins/docker-buildx
+docker buildx version
+docker buildx create --name builder-manylinux --driver docker-container --buildkitd-flags "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --use
+docker buildx inspect --bootstrap --builder builder-manylinux


### PR DESCRIPTION
Now that pypa has some credits on travis-ci again, move back arm64 & s390x on travis-ci where builds are done natively.

ppc64le seems to have trouble with buildx for now so still on GHA