### PR TITLE
Build ppc64le on travis-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,10 @@ jobs:
             platform: "i686"
           - policy: "manylinux2014"
             platform: "x86_64"
-          - policy: "manylinux2014"
-            platform: "ppc64le"
           - policy: "manylinux_2_24"
             platform: "i686"
           - policy: "manylinux_2_24"
             platform: "x86_64"
-          - policy: "manylinux_2_24"
-            platform: "ppc64le"
 
     env:
       POLICY: ${{ matrix.policy }}
@@ -47,12 +43,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        if: matrix.platform == 'ppc64le'
-        uses: docker/setup-qemu-action@v1.0.1
-        with:
-          platforms: ppc64le
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,21 +28,23 @@ jobs:
       env: POLICY="manylinux2014" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux2014" PLATFORM="s390x"
-    #- arch: ppc64le
-    #  env: POLICY="manylinux2014" PLATFORM="ppc64le"
+    - arch: ppc64le
+      env: POLICY="manylinux2014" PLATFORM="ppc64le"
     - arch: arm64-graviton2
       virt: vm
       group: edge
       env: POLICY="manylinux_2_24" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux_2_24" PLATFORM="s390x"
-    #- arch: ppc64le
-    #  env: POLICY="manylinux2014" PLATFORM="ppc64le"
+    - arch: ppc64le
+      env: POLICY="manylinux_2_24" PLATFORM="ppc64le"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi
 
 install:
+  - nproc
+  - free
   - ./travisci-install-buildx.sh
 
 script:
@@ -57,3 +59,7 @@ deploy:
   on:
     branch: master
     repo: pypa/manylinux
+
+after_script:
+  - if [ -f ${HOME}/dockerd-rootless.pid ]; then kill -15 $(cat ${HOME}/dockerd-rootless.pid); fi
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,31 +116,26 @@ COPY build_scripts/build-cpython.sh /build_scripts/
 
 FROM build_cpython AS build_cpython36
 COPY build_scripts/cpython-pubkeys.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint gpg --import /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.6.13
 
 
 FROM build_cpython AS build_cpython37
 COPY build_scripts/cpython-pubkeys.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint gpg --import /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.7.10
 
 
 FROM build_cpython AS build_cpython38
-COPY build_scripts/ambv-pubkey.txt /build_scripts/ambv-pubkey.txt
-RUN manylinux-entrypoint gpg --import /build_scripts/ambv-pubkey.txt
+COPY build_scripts/ambv-pubkey.txt /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.8.10
 
 
 FROM build_cpython AS build_cpython39
-COPY build_scripts/ambv-pubkey.txt /build_scripts/ambv-pubkey.txt
-RUN manylinux-entrypoint gpg --import /build_scripts/ambv-pubkey.txt
+COPY build_scripts/ambv-pubkey.txt /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.9.5
 
 
 FROM build_cpython AS build_cpython310
-COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkey-310-311.txt
-RUN manylinux-entrypoint gpg --import /build_scripts/cpython-pubkey-310-311.txt
+COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkeys.txt
 RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0b1
 
 

--- a/docker/build_scripts/build-cmake.sh
+++ b/docker/build_scripts/build-cmake.sh
@@ -23,8 +23,8 @@ export CPPFLAGS="${MANYLINUX_CPPFLAGS}"
 export CFLAGS="${MANYLINUX_CFLAGS} ${CPPFLAGS}"
 export CXXFLAGS="${MANYLINUX_CXXFLAGS} ${CPPFLAGS}"
 export LDFLAGS="${MANYLINUX_LDFLAGS}"
-./bootstrap --system-curl --parallel=$(nproc)
-make -j$(nproc)
+./bootstrap --system-curl
+make
 make install DESTDIR=/manylinux-rootfs
 popd
 rm -rf cmake-${CMAKE_VERSION}.tar.gz cmake-${CMAKE_VERSION}

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -27,6 +27,7 @@ function pyver_dist_dir {
 CPYTHON_DIST_DIR=$(pyver_dist_dir ${CPYTHON_VERSION})
 fetch_source Python-${CPYTHON_VERSION}.tgz ${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}
 fetch_source Python-${CPYTHON_VERSION}.tgz.asc ${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}
+gpg --import ${MY_DIR}/cpython-pubkeys.txt
 gpg --verify Python-${CPYTHON_VERSION}.tgz.asc
 tar -xzf Python-${CPYTHON_VERSION}.tgz
 pushd Python-${CPYTHON_VERSION}

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -38,8 +38,8 @@ mkdir -p ${PREFIX}/lib
 	CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}" \
 	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS}" \
 	--prefix=${PREFIX} --disable-shared --with-ensurepip=no > /dev/null
-make -j$(nproc) > /dev/null
-make -j$(nproc) install > /dev/null
+make > /dev/null
+make install > /dev/null
 popd
 rm -rf Python-${CPYTHON_VERSION} Python-${CPYTHON_VERSION}.tgz Python-${CPYTHON_VERSION}.tgz.asc
 

--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -19,7 +19,7 @@ fetch_source ${GIT_ROOT}.tar.gz ${GIT_DOWNLOAD_URL}
 check_sha256sum ${GIT_ROOT}.tar.gz ${GIT_HASH}
 tar -xzf ${GIT_ROOT}.tar.gz
 pushd ${GIT_ROOT}
-make -j$(nproc) install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}"
+make install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}"
 popd
 rm -rf ${GIT_ROOT} ${GIT_ROOT}.tar.gz
 

--- a/docker/build_scripts/build-swig.sh
+++ b/docker/build_scripts/build-swig.sh
@@ -30,7 +30,7 @@ export CXXFLAGS="${MANYLINUX_CXXFLAGS}"
 export LDFLAGS="${MANYLINUX_LDFLAGS}"
 ./Tools/pcre-build.sh
 ./configure
-make -j$(nproc)
+make
 make install DESTDIR=/manylinux-rootfs
 popd
 rm -rf ${SWIG_ROOT}*

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -48,8 +48,8 @@ function check_sha256sum {
 
 function do_standard_install {
     ./configure "$@" CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" "CXXFLAGS=${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}" > /dev/null
-    make -j$(nproc) > /dev/null
-    make -j$(nproc) install > /dev/null
+    make > /dev/null
+    make install > /dev/null
 }
 
 function strip_ {

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -12,9 +12,40 @@ elif [ ${BUILDX_MACHINE} == "aarch64" ]; then
 	BUILDX_MACHINE=arm64
 fi
 
+if [ ${BUILDX_MACHINE} == "ppc64le" ]; then
+	# We need to run a rootless docker daemon due to travis-ci LXD configuration
+	# Update docker, c.f. https://developer.ibm.com/components/ibm-power/tutorials/install-docker-on-linux-on-power/
+	sudo systemctl stop docker
+	sudo apt-get update
+	sudo apt-get remove -y docker docker.io containerd runc
+	sudo apt-get install -y --no-install-recommends containerd uidmap slirp4netns fuse-overlayfs
+	curl -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce-cli_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	curl -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	curl -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce-rootless-extras_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	# prevent the docker service to start upon installation
+	echo -e '#!/bin/sh\nexit 101' | sudo tee /usr/sbin/policy-rc.d
+	sudo chmod +x /usr/sbin/policy-rc.d
+	# install docker
+	sudo dpkg -i docker-ce-cli_20.10.6~3-0~ubuntu-focal_ppc64el.deb docker-ce-rootless-extras_20.10.6~3-0~ubuntu-focal_ppc64el.deb docker-ce_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	# "restore" policy-rc.d
+	sudo rm -f /usr/sbin/policy-rc.d
+	# prepare & start the rootless docker daemon
+	dockerd-rootless-setuptool.sh install --force
+	export XDG_RUNTIME_DIR=/home/travis/.docker/run
+	dockerd-rootless.sh &> /dev/null &
+	DOCKERD_ROOTLESS_PID=$!
+	echo "${DOCKERD_ROOTLESS_PID}" > ${HOME}/dockerd-rootless.pid
+	docker context use rootless
+fi
 mkdir -vp ~/.docker/cli-plugins/
 curl -sSL "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-${BUILDX_MACHINE}" > ~/.docker/cli-plugins/docker-buildx
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 docker buildx version
-docker buildx create --name builder-manylinux --driver docker-container --buildkitd-flags "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host" --use
+
+docker buildx create --name builder-manylinux --driver docker-container --use
+if [ ${BUILDX_MACHINE} == "ppc64le" ]; then
+	# start the container without --userns=host
+	# https://github.com/docker/buildx/issues/561
+	docker run -d --name buildx_buildkit_builder-manylinux0 --privileged moby/buildkit:buildx-stable-1
+fi
 docker buildx inspect --bootstrap --builder builder-manylinux


### PR DESCRIPTION
Now that pypa has some credits on travis-ci again, move back ppc64le on travis-ci where builds are done natively.

- We need to run a rootless docker daemon on ppc64le due to travis-ci LXD configuration but this is better than the
6 hour build on GHA reaching the time limit now & then. We can still go back to QEMU GHA if things prove unstable.

- Disable parallel builds: Given the dockerfile uses multiple unrelated stages & that we're using buildx/buildkit which parallelize those stages, parallelizing builds at each stage does not improve build speed that much and puts too much RAM pressure leading to random failures in CI.

- Workaround GPG issue with ppc64le build: Seems there's an issue with GPG when using the rootless docker daemon,
the import statement and the verify statement must be in the same layer.