### PR TITLE
Only setup QEMU for ppc64le builds on GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
+        if: matrix.platform == 'ppc64le'
         uses: docker/setup-qemu-action@v1.0.1
+        with:
+          platforms: ppc64le
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Seems that QEMU is now used for i686 which slows down the builds.
Only use QEMU when needed.