### PR TITLE
CPython 3.6.{12→13}, 3.7.{9→10}; OpenSSL 1.1.1{i→j}

### DIFF
--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -2,7 +2,7 @@
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 # of the form <maj>.<min>.<rev> or <maj>.<min>.<rev>rc<n>
-CPYTHON_VERSIONS="2.7.18 3.5.10 3.6.12 3.7.9 3.8.7 3.9.1"
+CPYTHON_VERSIONS="2.7.18 3.5.10 3.6.13 3.7.10 3.8.7 3.9.1"
 
 # perl is needed to build openssl
 PERL_ROOT=perl-5.30.2
@@ -11,8 +11,8 @@ PERL_DOWNLOAD_URL=https://www.cpan.org/src/5.0
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.
-OPENSSL_ROOT=openssl-1.1.1i
-OPENSSL_HASH=e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+OPENSSL_ROOT=openssl-1.1.1j
+OPENSSL_HASH=aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
 PATCHELF_VERSION=0.12


### PR DESCRIPTION
CPython changelogs:
https://docs.python.org/release/3.6.13/whatsnew/changelog.html
https://docs.python.org/release/3.7.10/whatsnew/changelog.html

OpenSSL changelog:
https://www.openssl.org/news/cl111.txt
Fixes CVE-2021-23840 and CVE-2021-23841