### PR TITLE
Build hardening

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,18 +21,17 @@ ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH_ARG}
 ENV PATH=${PREPEND_PATH}${PATH}
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
-# first fixup mirrors, keep the script around
+# first copy the fixup mirrors script, keep the script around
 COPY build_scripts/fixup-mirrors.sh /usr/local/sbin/fixup-mirrors
-RUN fixup-mirrors
 
 # setup entrypoint, this will wrap commands with `linux32` with i686 images
-COPY build_scripts/install-entrypoint.sh /build_scripts/
-RUN bash /build_scripts/install-entrypoint.sh && rm -rf build_scripts
+COPY build_scripts/install-entrypoint.sh build_scripts/update-system-packages.sh /build_scripts/
+RUN bash /build_scripts/install-entrypoint.sh && rm -rf /build_scripts
 COPY manylinux-entrypoint /usr/local/bin/manylinux-entrypoint
 ENTRYPOINT ["manylinux-entrypoint"]
 
-COPY build_scripts/install-runtime-packages.sh /build_scripts/
-RUN manylinux-entrypoint /build_scripts/install-runtime-packages.sh && rm /build_scripts/install-runtime-packages.sh
+COPY build_scripts/install-runtime-packages.sh build_scripts/update-system-packages.sh /build_scripts/
+RUN manylinux-entrypoint /build_scripts/install-runtime-packages.sh && rm -rf /build_scripts/
 
 COPY build_scripts/build_utils.sh /build_scripts/
 
@@ -160,7 +159,7 @@ COPY --from=build_cmake /manylinux-rootfs /
 COPY --from=build_swig /manylinux-rootfs /
 COPY --from=build_cpython /manylinux-rootfs /
 COPY --from=all_cpython /opt/_internal /opt/_internal/
-COPY build_scripts/finalize.sh build_scripts/python-tag-abi-tag.py build_scripts/requirements.txt build_scripts/requirements-tools.txt /build_scripts/
+COPY build_scripts/finalize.sh build_scripts/update-system-packages.sh build_scripts/python-tag-abi-tag.py build_scripts/requirements.txt build_scripts/requirements-tools.txt /build_scripts/
 RUN manylinux-entrypoint /build_scripts/finalize.sh && rm -rf /build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem

--- a/docker/build_scripts/build-cmake.sh
+++ b/docker/build_scripts/build-cmake.sh
@@ -19,6 +19,10 @@ fetch_source cmake-${CMAKE_VERSION}.tar.gz ${CMAKE_DOWNLOAD_URL}/v${CMAKE_VERSIO
 check_sha256sum cmake-${CMAKE_VERSION}.tar.gz ${CMAKE_HASH}
 tar -xzf cmake-${CMAKE_VERSION}.tar.gz
 pushd cmake-${CMAKE_VERSION}
+export CPPFLAGS="${MANYLINUX_CPPFLAGS}"
+export CFLAGS="${MANYLINUX_CFLAGS} ${CPPFLAGS}"
+export CXXFLAGS="${MANYLINUX_CXXFLAGS} ${CPPFLAGS}"
+export LDFLAGS="${MANYLINUX_LDFLAGS}"
 ./bootstrap --system-curl --parallel=$(nproc)
 make -j$(nproc)
 make install DESTDIR=/manylinux-rootfs

--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -19,7 +19,7 @@ fetch_source ${GIT_ROOT}.tar.gz ${GIT_DOWNLOAD_URL}
 check_sha256sum ${GIT_ROOT}.tar.gz ${GIT_HASH}
 tar -xzf ${GIT_ROOT}.tar.gz
 pushd ${GIT_ROOT}
-make -j$(nproc) install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs
+make -j$(nproc) install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}"
 popd
 rm -rf ${GIT_ROOT} ${GIT_ROOT}.tar.gz
 

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -35,7 +35,7 @@ fetch_source ${OPENSSL_ROOT}.tar.gz ${OPENSSL_DOWNLOAD_URL}
 check_sha256sum ${OPENSSL_ROOT}.tar.gz ${OPENSSL_HASH}
 tar -xzf ${OPENSSL_ROOT}.tar.gz
 pushd ${OPENSSL_ROOT}
-./config no-shared -fPIC --prefix=/usr/local/ssl --openssldir=/usr/local/ssl > /dev/null
+./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS} -fPIC" CXXFLAGS="${MANYLINUX_CXXFLAGS} -fPIC" LDFLAGS="${MANYLINUX_LDFLAGS} -fPIC" > /dev/null
 make > /dev/null
 make install_sw > /dev/null
 popd

--- a/docker/build_scripts/build-swig.sh
+++ b/docker/build_scripts/build-swig.sh
@@ -24,6 +24,10 @@ tar -xzf ${SWIG_ROOT}.tar.gz
 pushd ${SWIG_ROOT}
 fetch_source ${PCRE_ROOT}.tar.gz ${PCRE_DOWNLOAD_URL}
 check_sha256sum ${PCRE_ROOT}.tar.gz ${PCRE_HASH}
+export CPPFLAGS="${MANYLINUX_CPPFLAGS}"
+export CFLAGS="${MANYLINUX_CFLAGS}"
+export CXXFLAGS="${MANYLINUX_CXXFLAGS}"
+export LDFLAGS="${MANYLINUX_LDFLAGS}"
 ./Tools/pcre-build.sh
 ./configure
 make -j$(nproc)

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -2,6 +2,15 @@
 # Helper utilities for build
 
 
+# use all flags used by ubuntu 20.04 for hardening builds, dpkg-buildflags --export
+# other flags mentioned in https://wiki.ubuntu.com/ToolChain/CompilerFlags can't be
+# used because the distros used here are too old
+MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
+MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
+
+
 function check_var {
     if [ -z "$1" ]; then
         echo "required variable not defined"
@@ -38,7 +47,7 @@ function check_sha256sum {
 
 
 function do_standard_install {
-    ./configure "$@" > /dev/null
+    ./configure "$@" CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" "CXXFLAGS=${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}" > /dev/null
     make -j$(nproc) > /dev/null
     make -j$(nproc) install > /dev/null
 }

--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -59,3 +59,7 @@ clean_pyc /opt/_internal
 rm -rf /root/.cache
 
 hardlink -cv /opt/_internal
+
+# update system packages
+LC_ALL=C ${MY_DIR}/update-system-packages.sh
+

--- a/docker/build_scripts/install-entrypoint.sh
+++ b/docker/build_scripts/install-entrypoint.sh
@@ -5,10 +5,19 @@
 # Stop at any error, show all commands
 set -exuo pipefail
 
+# Set build environment variables
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+
 if [ "${AUDITWHEEL_PLAT}" == "manylinux2010_i686" ] || [ "${AUDITWHEEL_PLAT}" == "manylinux2014_i686" ]; then
 	echo "i386" > /etc/yum/vars/basearch
+	fixup-mirrors
 	yum -y update
+	fixup-mirrors
 	yum install -y util-linux-ng
-	yum clean all
-	rm -rf /var/cache/yum
+	# update system packages, we already updated them but
+	# the following script takes care of cleaning-up some things
+	# and since it's also needed in the finalize step, everything's
+	# centralized in this script to avoid code duplication
+	LC_ALL=C ${MY_DIR}/update-system-packages.sh
 fi

--- a/docker/build_scripts/update-system-packages.sh
+++ b/docker/build_scripts/update-system-packages.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Update system packages
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+
+fixup-mirrors
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
+	yum -y update
+	if ! localedef -V &> /dev/null; then
+		# somebody messed up glibc-common package to squeeze image size, reinstall the package
+		fixup-mirrors
+		yum -y reinstall glibc-common
+	fi
+	yum clean all
+	rm -rf /var/cache/yum
+elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
+	export DEBIAN_FRONTEND=noninteractive
+	apt-get update -qq
+	apt-get upgrade -qq -y
+	apt-get clean -qq
+	rm -rf /var/lib/apt/lists/*
+else
+	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"
+	exit 1
+fi
+fixup-mirrors
+
+# do we want to update locales ?
+LOCALE_ARCHIVE=/usr/lib/locale/locale-archive
+TIMESTAMP_FILE=${LOCALE_ARCHIVE}.ml.timestamp
+if [ ! -f ${TIMESTAMP_FILE} ] || [ ${LOCALE_ARCHIVE} -nt ${TIMESTAMP_FILE} ]; then
+	# upgrading glibc-common can end with removal on en_US.UTF-8 locale
+	localedef -i en_US -f UTF-8 en_US.UTF-8
+
+	# if we updated glibc, we need to strip locales again...
+	if localedef --list-archive | grep -sq -v -i ^en_US.utf8; then
+		localedef --list-archive | grep -v -i ^en_US.utf8 | xargs localedef --delete-from-archive
+	fi
+	if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ]; then
+		mv -f ${LOCALE_ARCHIVE} ${LOCALE_ARCHIVE}.tmpl
+		build-locale-archive --install-langs="en_US.utf8"
+	elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
+		rm ${LOCALE_ARCHIVE}
+		localedef -i en_US -f UTF-8 en_US.UTF-8
+		update-locale LANG=en_US.UTF-8
+	fi
+	touch ${TIMESTAMP_FILE}
+fi
+
+if [ -d /usr/share/locale ]; then
+	find /usr/share/locale -mindepth 1 -maxdepth 1 -not \( -name 'en*' -or -name 'locale.alias' \) | xargs rm -rf
+fi
+if [ -d /usr/local/share/locale ]; then
+	find /usr/local/share/locale -mindepth 1 -maxdepth 1 -not \( -name 'en*' -or -name 'locale.alias' \) | xargs rm -rf
+fi
+
+# Fix libc headers to remain compatible with C99 compilers.
+find /usr/include/ -type f -exec sed -i 's/\bextern _*inline_*\b/extern __inline __attribute__ ((__gnu_inline__))/g' {} +
+
+if [ "${DEVTOOLSET_ROOTPATH:-}" != "" ]; then
+	# remove useless things that have been installed/updated by devtoolset
+	if [ -d $DEVTOOLSET_ROOTPATH/usr/share/man ]; then
+		rm -rf $DEVTOOLSET_ROOTPATH/usr/share/man
+	fi
+	if [ -d $DEVTOOLSET_ROOTPATH/usr/share/locale ]; then
+		find $DEVTOOLSET_ROOTPATH/usr/share/locale -mindepth 1 -maxdepth 1 -not \( -name 'en*' -or -name 'locale.alias' \) | xargs rm -rf
+	fi
+fi
+
+if [ -d /usr/share/backgrounds ]; then
+	rm -rf /usr/share/backgrounds
+fi
+
+if [ -d /usr/local/share/man ]; then
+	rm -rf /usr/local/share/man
+fi


### PR DESCRIPTION
- Use hardening for building all tools & libraries
This does not affect the wheels that are produced by end users as proposed in #59 but mitigates potential security issues in the tools used by manylinux images as mentioned in #1005
- Always update system packages in the final step
Since docker cache is used, system packages are not updated when cache is present. Always update them in the final step.