### PR TITLE
Fix libxcrypt install on manylinux_2_24

### DIFF
--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -48,4 +48,5 @@ rm -rf /manylinux-rootfs
 
 # Delete GLIBC version headers and libraries
 rm -rf /usr/include/crypt.h
-rm -rf /usr/lib*/libcrypt.a /usr/lib*/libcrypt.so /usr/lib*/libcrypt.so.1
+find /lib* /usr/lib* \( -name 'libcrypt.a' -o -name 'libcrypt.so' -o -name 'libcrypt.so.*' -o -name 'libcrypt-2.*.so' \) -delete
+ldconfig

--- a/docker/build_scripts/update-system-packages.sh
+++ b/docker/build_scripts/update-system-packages.sh
@@ -76,3 +76,9 @@ fi
 if [ -d /usr/local/share/man ]; then
 	rm -rf /usr/local/share/man
 fi
+
+if [ -f /usr/local/lib/libcrypt.so.1 ]; then
+	# Remove libcrypt to only use installed libxcrypt instead
+	find /lib* /usr/lib* \( -name 'libcrypt.a' -o -name 'libcrypt.so' -o -name 'libcrypt.so.*' -o -name 'libcrypt-2.*.so' \) -delete
+	ldconfig
+fi


### PR DESCRIPTION
libcrypt is not at the same place on Debian systems.
Update the replacement of libcrypt by libxcrypt so that Debian systems use libxcrypt as well.