### PR TITLE
Fix library search order on manylinux_2_24_i686/aarch64

### DIFF
--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -129,5 +129,5 @@ LC_ALL=C ${MY_DIR}/update-system-packages.sh
 # this is needed to ensure the new one will be found
 # as LD_LIBRARY_PATH does not seem enough.
 # c.f. https://github.com/pypa/manylinux/issues/1022
-echo "/usr/local/lib" > /etc/ld.so.conf.d/manylinux.conf
+echo "/usr/local/lib" > /etc/ld.so.conf.d/00-manylinux.conf
 ldconfig

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -24,9 +24,9 @@ for PYTHON in /opt/python/*/bin/python; do
 	$PYTHON $MY_DIR/manylinux-check.py ${AUDITWHEEL_POLICY} ${AUDITWHEEL_ARCH}
 	# Make sure that SSL cert checking works
 	$PYTHON $MY_DIR/ssl-check.py
-	# Make sure sqlite3 module can be loaded properly
+	# Make sure sqlite3 module can be loaded properly and is the manylinux version one
 	# c.f. https://github.com/pypa/manylinux/issues/1030
-	$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version)'
+	$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version); assert sqlite3.sqlite_version_info[0:2] >= (3, 34)'
 done
 
 # minimal tests for tools that should be present


### PR DESCRIPTION
Fix _sqlite3 loading the system sqlite version instead of the custom one.

c.f. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=685706