### PR TITLE
sqlite3 headers

### DIFF
--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -33,5 +33,4 @@ cp -rlf /manylinux-rootfs/* /
 ldconfig
 
 # Clean-up for runtime
-rm -rf /manylinux-rootfs/usr/local/bin /manylinux-rootfs/usr/local/include /manylinux-rootfs/usr/local/lib/pkg-config /manylinux-rootfs/usr/local/share
-find -L /manylinux-rootfs -type f -a -not -name 'libsqlite3.so.*' -delete
+rm -rf /manylinux-rootfs/usr/local/bin /manylinux-rootfs/usr/local/share

--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -33,4 +33,4 @@ cp -rlf /manylinux-rootfs/* /
 ldconfig
 
 # Clean-up for runtime
-rm -rf /manylinux-rootfs/usr/local/bin /manylinux-rootfs/usr/local/share
+rm -rf /manylinux-rootfs/usr/local/share

--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CTest)
 
 # SQLite3 test Derived from CMake unit test for FindSQLite3
 # https://gitlab.kitware.com/cmake/cmake/-/tree/master/Tests/FindSQLite3/Test
-find_package(SQLite3 REQUIRED)
+find_package(SQLite3 3.34 REQUIRED)
 add_definitions(-DCMAKE_EXPECTED_SQLite3_VERSION="${SQLite3_VERSION}")
 add_executable(test_sqlite3 test_sqlite3.cpp)
 target_link_libraries(test_sqlite3 SQLite::SQLite3)

--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14.7)
+project(manylinux_ctest)
+include(CTest)
+
+# SQLite3 test Derived from CMake unit test for FindSQLite3
+# https://gitlab.kitware.com/cmake/cmake/-/tree/master/Tests/FindSQLite3/Test
+find_package(SQLite3 REQUIRED)
+add_definitions(-DCMAKE_EXPECTED_SQLite3_VERSION="${SQLite3_VERSION}")
+add_executable(test_sqlite3 test_sqlite3.cpp)
+target_link_libraries(test_sqlite3 SQLite::SQLite3)
+add_test(NAME test_sqlite3 COMMAND test_sqlite3)

--- a/tests/ctest/test_sqlite3.cpp
+++ b/tests/ctest/test_sqlite3.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <string>
+#include <sqlite3.h>
+
+int main()
+{
+  std::string expected_version = CMAKE_EXPECTED_SQLite3_VERSION;
+  std::string found_version = SQLITE_VERSION;
+  std::cout << "SQLite3: expecting version " << expected_version
+            << ", found verison " << found_version << std::endl;
+  return expected_version.compare(found_version);
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -37,6 +37,7 @@ patchelf --version
 git --version
 cmake --version
 swig -version
+sqlite3 --version
 
 # check libcrypt.so.1 can be loaded by some system packages,
 # as LD_LIBRARY_PATH might not be enough.
@@ -51,3 +52,14 @@ else
 fi
 eval "$(ssh-agent)"
 eval "$(ssh-agent -k)"
+
+# compilation tests, intended to ensure appropriate headers, pkg_config, etc.
+# are available for downstream compile against installed tools
+source_dir="${MY_DIR}/ctest"
+build_dir="$(mktemp -d)"
+cmake -S "${source_dir}" -B "${build_dir}"
+cmake --build "${build_dir}"
+(cd "${build_dir}"; ctest --output-on-failure)
+
+# final report
+echo "run_tests successful!"


### PR DESCRIPTION
Previous versions of manylinux2010 included sqlite3 files that allowed downstream dockers to build against the recent version of sqlite3 included in the docker image.  Files include:
- headers `/usr/local/include/{sqlite3.h,sqlite3ext.h}`
- pkgconfig file `/usr/local/lib/pkgconfig/sqlite3.pc`
- libtool file `/usr/local/lib/libsqlite3.la`
- .so file `/usr/local/lib/libsqlite3.so`

PR #972 eliminated these files during cleanup.  This PR restores the above files (which have a relatively small footprint).