### PR TITLE
[manylinux1] Remove useless kernel-devel-`uname -r` dependency

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -72,7 +72,6 @@ yum -y install \
     diffutils \
     expat-devel \
     gettext \
-    kernel-devel-`uname -r` \
     file \
     make \
     patch \


### PR DESCRIPTION
Remove useless kernel-devel-`uname -r` dependency

The package doesn't exist and thus is not installed.
Fix #1056