### PR TITLE
Do not break /usr/local layout

### DIFF
--- a/docker/build_scripts/update-system-packages.sh
+++ b/docker/build_scripts/update-system-packages.sh
@@ -74,7 +74,10 @@ if [ -d /usr/share/backgrounds ]; then
 fi
 
 if [ -d /usr/local/share/man ]; then
-	rm -rf /usr/local/share/man
+	# https://github.com/pypa/manylinux/issues/1060
+	# wrong /usr/local/man symlink
+	# only delete the content
+	rm -rf /usr/local/share/man/*
 fi
 
 if [ -f /usr/local/lib/libcrypt.so.1 ]; then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -61,5 +61,11 @@ cmake -S "${source_dir}" -B "${build_dir}"
 cmake --build "${build_dir}"
 (cd "${build_dir}"; ctest --output-on-failure)
 
+# https://github.com/pypa/manylinux/issues/1060
+# wrong /usr/local/man symlink
+if [ -L /usr/local/man ]; then
+	test -d /usr/local/man
+fi
+
 # final report
 echo "run_tests successful!"


### PR DESCRIPTION
Some distros are defining /usr/local/man to be a symlink to /usr/local/share/man

The clean-up done in update-system-packages.sh was a bit too aggressive and lead to breaking the symlink.
Only delete the content of /usr/local/share/man not to break the layout as defined by the distros.

Fix #1060