### PR TITLE
feat: add symlinks to pythonx.y versions

### DIFF
--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -26,6 +26,10 @@ for PREFIX in $(find /opt/_internal/ -mindepth 1 -maxdepth 1 -name 'cpython*'); 
 	# Create a symlink to PREFIX using the ABI_TAG in /opt/python/
 	ABI_TAG=$(${PREFIX}/bin/python ${MY_DIR}/python-tag-abi-tag.py)
 	ln -s ${PREFIX} /opt/python/${ABI_TAG}
+	# Make versioned python commands available directly in environment.
+	PYVERS=$(${PREFIX}/bin/python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
+	ln -s ${PREFIX}/bin/python /usr/local/bin/python${PYVERS}
+	ln -s ${PREFIX}/bin/pip /usr/local/bin/pip${PYVERS}
 done
 
 # Create venv for auditwheel & certifi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -27,6 +27,14 @@ for PYTHON in /opt/python/*/bin/python; do
 	# Make sure sqlite3 module can be loaded properly and is the manylinux version one
 	# c.f. https://github.com/pypa/manylinux/issues/1030
 	$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version); assert sqlite3.sqlite_version_info[0:2] >= (3, 34)'
+	# pythonx.y & pipx.y shall be available directly in PATH
+	PYVERS=$(${PYTHON} -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
+	LINK_VERSION=$(python${PYVERS} -V)
+	REAL_VERSION=$(${PYTHON} -V)
+	test "${LINK_VERSION}" = "${REAL_VERSION}"
+	LINK_VERSION=$(pip${PYVERS} -V)
+	REAL_VERSION=$(${PYTHON} -m pip -V)
+	test "${LINK_VERSION%% from *}" = "${REAL_VERSION%% from *}"
 done
 
 # minimal tests for tools that should be present


### PR DESCRIPTION
This is the addition of symlinks mentioned in https://github.com/joerick/cibuildwheel/pull/661; this makes it easier for tools that try to discover multiple Python versions, like Tox/virtualenv/Nox, to use the manylinux images.

A further idea would be to add `python` and `python3` symlinks to a non-system version of Python.
