### PR TITLE
Exclude package mirror with broken metadata

### DIFF
--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -79,6 +79,8 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
 	echo "skip_missing_names_on_install=False" >> /etc/yum.conf
 	# Make sure that locale will not be removed
 	sed -i '/^override_install_langs=/d' /etc/yum.conf
+	# Exclude mirror holding broken package metadata
+	echo "exclude = d36uatko69830t.cloudfront.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
 	yum -y update
 	yum -y install yum-utils curl
 	yum-config-manager --enable extras


### PR DESCRIPTION
The package mirror favored by manylinux2014 aarch64 builds on travis-ci holds broken metadata.
Add it to the mirror exclusion list to fix the build.