### PR TITLE
Make sure pipx installed apps are in the PATH

### DIFF
--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -45,8 +45,19 @@ pip install -U --require-hashes -r $MY_DIR/requirements-tools.txt
 # Make auditwheel available in PATH
 ln -s $TOOLS_PATH/bin/auditwheel /usr/local/bin/auditwheel
 
-# Make pipx available in PATH
-ln -s $TOOLS_PATH/bin/pipx /usr/local/bin/pipx
+# Make pipx available in PATH,
+# Make sure when root installs apps, they're also in the PATH
+cat <<EOF > /usr/local/bin/pipx
+#!/bin/bash
+
+set -euo pipefail
+
+if [ \$(id -u) -eq 0 ]; then
+	export PIPX_BIN_DIR=/usr/local/bin
+fi
+${TOOLS_PATH}/bin/pipx \$*
+EOF
+chmod 755 /usr/local/bin/pipx
 
 # Our openssl doesn't know how to find the system CA trust store
 #   (https://github.com/pypa/manylinux/issues/53)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -47,6 +47,8 @@ cmake --version
 swig -version
 sqlite3 --version
 pipx run nox --version
+pipx install nox
+nox --version
 
 # check libcrypt.so.1 can be loaded by some system packages,
 # as LD_LIBRARY_PATH might not be enough.


### PR DESCRIPTION
Allows for example `pipx install ninja` in a pre-build step, with `ninja` being installed in the PATH.

Other solution would be to expand PATH but this seems messy if someone extends the docker image using non-root user.
Tools from the image (i.e. auditwheel) can't be overwritten without using the `--force` flag i.e. `pipx install --force "auditwheel==3.3.1"` 