### PR TITLE
Remove pipx.y symlinks in /usr/local/bin

### DIFF
--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -29,7 +29,6 @@ for PREFIX in $(find /opt/_internal/ -mindepth 1 -maxdepth 1 -name 'cpython*'); 
 	# Make versioned python commands available directly in environment.
 	PYVERS=$(${PREFIX}/bin/python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 	ln -s ${PREFIX}/bin/python /usr/local/bin/python${PYVERS}
-	ln -s ${PREFIX}/bin/pip /usr/local/bin/pip${PYVERS}
 done
 
 # Create venv for auditwheel & certifi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -27,14 +27,11 @@ for PYTHON in /opt/python/*/bin/python; do
 	# Make sure sqlite3 module can be loaded properly and is the manylinux version one
 	# c.f. https://github.com/pypa/manylinux/issues/1030
 	$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version); assert sqlite3.sqlite_version_info[0:2] >= (3, 34)'
-	# pythonx.y & pipx.y shall be available directly in PATH
+	# pythonx.y shall be available directly in PATH
 	PYVERS=$(${PYTHON} -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 	LINK_VERSION=$(python${PYVERS} -V)
 	REAL_VERSION=$(${PYTHON} -V)
 	test "${LINK_VERSION}" = "${REAL_VERSION}"
-	LINK_VERSION=$(pip${PYVERS} -V)
-	REAL_VERSION=$(${PYTHON} -m pip -V)
-	test "${LINK_VERSION%% from *}" = "${REAL_VERSION%% from *}"
 done
 
 # minimal tests for tools that should be present


### PR DESCRIPTION
For the sake of consistency when we'll add PyPy in #1103 and given the fact that pipx.y symlinks were introduced very recently, remove those symlinks.
Use `pythonx.y -m pip` instead.