### PR TITLE
Do not build `update-dependencies-pr` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches-ignore:
-      - "dependabot/**"
+      - "update-dependencies-pr"
     paths:
       - ".github/workflows/build.yml"
       - "docker/**"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ dist: focal
 services:
   - docker
 
-# Don't build the depandabot branches that dependabot creates; it's redundant
+# Don't build the update-dependencies-pr branch; it's redundant
 # with the PR builds that Travis also does.
 branches:
   except:
-    - /^dependabot/
+    - /^update-dependencies-pr/
 
 cache:
   directories:


### PR DESCRIPTION
Those builds are redundant with the PR builds.