### PR TITLE
chore: bump CPython 3.10.0b1 -> 3.10.0b2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,7 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.9.5
 
 FROM build_cpython AS build_cpython310
 COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0b1
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0b2
 
 
 FROM build_cpython AS all_python


### PR DESCRIPTION
Changelog: https://docs.python.org/3.10/whatsnew/3.10.html 