### PR TITLE
feat: allow building with docker, docker buildx & buildkit frontends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - arch: s390x
       env: POLICY="manylinux2014" PLATFORM="s390x"
     - arch: ppc64le
-      env: POLICY="manylinux2014" PLATFORM="ppc64le"
+      env: POLICY="manylinux2014" PLATFORM="ppc64le" MANYLINUX_BUILD_FRONTEND="buildkit"
     - arch: arm64-graviton2
       virt: vm
       group: edge
@@ -37,7 +37,7 @@ jobs:
     - arch: s390x
       env: POLICY="manylinux_2_24" PLATFORM="s390x"
     - arch: ppc64le
-      env: POLICY="manylinux_2_24" PLATFORM="ppc64le"
+      env: POLICY="manylinux_2_24" PLATFORM="ppc64le" MANYLINUX_BUILD_FRONTEND="buildkit"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi
@@ -62,4 +62,4 @@ deploy:
 
 after_script:
   - if [ -f ${HOME}/dockerd-rootless.pid ]; then kill -15 $(cat ${HOME}/dockerd-rootless.pid); fi
-
+  - if [ -f /tmp/buildkitd.pid ]; then sudo kill -15 $(cat /tmp/buildkitd.pid); fi

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,10 @@
 # Stop at any error, show all commands
 set -exuo pipefail
 
+if [ "${MANYLINUX_BUILD_FRONTEND:-}" == "" ]; then
+	MANYLINUX_BUILD_FRONTEND="docker-buildx"
+fi
+
 # Export variable needed by 'docker build --build-arg'
 export POLICY
 export PLATFORM
@@ -67,18 +71,41 @@ export DEVTOOLSET_ROOTPATH
 export PREPEND_PATH
 export LD_LIBRARY_PATH_ARG
 
-docker buildx build \
-	--load \
-	--cache-from=type=local,src=$(pwd)/.buildx-cache-${POLICY}_${PLATFORM} \
-	--cache-to=type=local,dest=$(pwd)/.buildx-cache-staging-${POLICY}_${PLATFORM} \
-	--build-arg POLICY --build-arg PLATFORM --build-arg BASEIMAGE \
-	--build-arg DEVTOOLSET_ROOTPATH --build-arg PREPEND_PATH --build-arg LD_LIBRARY_PATH_ARG \
-	--rm -t quay.io/pypa/${POLICY}_${PLATFORM}:${COMMIT_SHA} \
+BUILD_ARGS_COMMON="
+	--build-arg POLICY --build-arg PLATFORM --build-arg BASEIMAGE
+	--build-arg DEVTOOLSET_ROOTPATH --build-arg PREPEND_PATH --build-arg LD_LIBRARY_PATH_ARG
+	--rm -t quay.io/pypa/${POLICY}_${PLATFORM}:${COMMIT_SHA}
 	-f docker/Dockerfile docker/
+"
+
+if [ "${MANYLINUX_BUILD_FRONTEND}" == "docker" ]; then
+	docker build ${BUILD_ARGS_COMMON}
+elif [ "${MANYLINUX_BUILD_FRONTEND}" == "docker-buildx" ]; then
+	docker buildx build \
+		--load \
+		--cache-from=type=local,src=$(pwd)/.buildx-cache-${POLICY}_${PLATFORM} \
+		--cache-to=type=local,dest=$(pwd)/.buildx-cache-staging-${POLICY}_${PLATFORM} \
+		${BUILD_ARGS_COMMON}
+elif [ "${MANYLINUX_BUILD_FRONTEND}" == "buildkit" ]; then
+	buildctl build \
+		--frontend=dockerfile.v0 \
+		--local context=./docker/ \
+		--local dockerfile=./docker/ \
+		--import-cache type=local,src=$(pwd)/.buildx-cache-${POLICY}_${PLATFORM} \
+		--export-cache type=local,dest=$(pwd)/.buildx-cache-staging-${POLICY}_${PLATFORM} \
+		--opt build-arg:POLICY=${POLICY} --opt build-arg:PLATFORM=${PLATFORM} --opt build-arg:BASEIMAGE=${BASEIMAGE} \
+		--opt "build-arg:DEVTOOLSET_ROOTPATH=${DEVTOOLSET_ROOTPATH}" --opt "build-arg:PREPEND_PATH=${PREPEND_PATH}" --opt "build-arg:LD_LIBRARY_PATH_ARG=${LD_LIBRARY_PATH_ARG}" \
+		--output type=docker,name=quay.io/pypa/${POLICY}_${PLATFORM}:${COMMIT_SHA} | docker load
+else
+	echo "Unsupported build frontend: '${MANYLINUX_BUILD_FRONTEND}'"
+	exit 1
+fi
 
 docker run --rm -v $(pwd)/tests:/tests:ro quay.io/pypa/${POLICY}_${PLATFORM}:${COMMIT_SHA} /tests/run_tests.sh
 
-if [ -d $(pwd)/.buildx-cache-${POLICY}_${PLATFORM} ]; then
-	rm -rf $(pwd)/.buildx-cache-${POLICY}_${PLATFORM}
+if [ "${MANYLINUX_BUILD_FRONTEND}" != "docker" ]; then
+	if [ -d $(pwd)/.buildx-cache-${POLICY}_${PLATFORM} ]; then
+		rm -rf $(pwd)/.buildx-cache-${POLICY}_${PLATFORM}
+	fi
+	mv $(pwd)/.buildx-cache-staging-${POLICY}_${PLATFORM} $(pwd)/.buildx-cache-${POLICY}_${PLATFORM}
 fi
-mv $(pwd)/.buildx-cache-staging-${POLICY}_${PLATFORM} $(pwd)/.buildx-cache-${POLICY}_${PLATFORM}

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -44,6 +44,16 @@ EOF
 	DOCKERD_ROOTLESS_PID=$!
 	echo "${DOCKERD_ROOTLESS_PID}" > ${HOME}/dockerd-rootless.pid
 	docker context use rootless
+	DOCKER_WAIT_COUNT=0
+	while ! docker ps -q &>/dev/null; do
+		DOCKER_WAIT_COUNT=$(( ${DOCKER_WAIT_COUNT} + 1 ))
+		if [ ${DOCKER_WAIT_COUNT} -ge 12 ]; then
+			echo "Docker is still not running."
+			kill -15 $(cat ${HOME}/dockerd-rootless.pid)
+			exit 1
+		fi
+		sleep 5
+	done
 fi
 mkdir -vp ~/.docker/cli-plugins/
 curl -sSL "https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-${BUILDX_MACHINE}" > ~/.docker/cli-plugins/docker-buildx

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -20,13 +20,13 @@ if [ ${BUILDX_MACHINE} == "ppc64le" ]; then
 	sudo apt-get remove -y docker docker.io containerd runc
 	sudo apt-get install -y --no-install-recommends containerd uidmap slirp4netns fuse-overlayfs
 	# issues with SSL certificate expiring, let's go insecure & check sha256
-	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce-cli_20.10.6~3-0~ubuntu-focal_ppc64el.deb
-	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce_20.10.6~3-0~ubuntu-focal_ppc64el.deb
-	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.6/ubuntu-focal/docker-ce-rootless-extras_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.7/ubuntu-focal/docker-ce-cli_20.10.7~3-0~ubuntu-focal_ppc64el.deb
+	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.7/ubuntu-focal/docker-ce_20.10.7~3-0~ubuntu-focal_ppc64el.deb
+	curl --insecure -fsSLO https://oplab9.parqtec.unicamp.br/pub/ppc64el/docker/version-20.10.7/ubuntu-focal/docker-ce-rootless-extras_20.10.7~3-0~ubuntu-focal_ppc64el.deb
 	cat <<EOF > docker-ce-ppc64le.sha256
-e4304b2e20d79e94f0c4e105bb4abbddb637a83c0bad164a56660c65f0d77631  docker-ce_20.10.6~3-0~ubuntu-focal_ppc64el.deb
-cd31d12aee7bd91ccb726ab750d382631fcc21ae2de64ab9868dcd275bcfa112  docker-ce-cli_20.10.6~3-0~ubuntu-focal_ppc64el.deb
-0117a2edea9b2fa75410dc3f62e64ee82282bfe5b07c508b01508661ce2c3861  docker-ce-rootless-extras_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+c42f4a9c7a5a99ef3c68de63165af9779350dff4cf3d000a399cac4915a2f4d7  docker-ce-cli_20.10.7~3-0~ubuntu-focal_ppc64el.deb
+46b3c3f5886ccbc94aced0e773a7fba38847b1a9f3dcb36bb85e1d05776f66af  docker-ce-rootless-extras_20.10.7~3-0~ubuntu-focal_ppc64el.deb
+c65ffa273ade99ee62690e9f1289cec479849a164a34e5a9e5ce459fad48b485  docker-ce_20.10.7~3-0~ubuntu-focal_ppc64el.deb
 EOF
 	sha256sum -c docker-ce-ppc64le.sha256
 	rm -f docker-ce-ppc64le.sha256
@@ -34,7 +34,7 @@ EOF
 	echo -e '#!/bin/sh\nexit 101' | sudo tee /usr/sbin/policy-rc.d
 	sudo chmod +x /usr/sbin/policy-rc.d
 	# install docker
-	sudo dpkg -i docker-ce-cli_20.10.6~3-0~ubuntu-focal_ppc64el.deb docker-ce-rootless-extras_20.10.6~3-0~ubuntu-focal_ppc64el.deb docker-ce_20.10.6~3-0~ubuntu-focal_ppc64el.deb
+	sudo dpkg -i docker-ce-cli_20.10.7~3-0~ubuntu-focal_ppc64el.deb docker-ce-rootless-extras_20.10.7~3-0~ubuntu-focal_ppc64el.deb docker-ce_20.10.7~3-0~ubuntu-focal_ppc64el.deb
 	# "restore" policy-rc.d
 	sudo rm -f /usr/sbin/policy-rc.d
 	# prepare & start the rootless docker daemon


### PR DESCRIPTION
Still default to `docker buildx` frontend

This allows for CI to work again on ppc64le (failing since Travis-CI changed the kernel version)