### PR TITLE
fix: pipx wrapper does not handle space in quoted argument

### DIFF
--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -64,7 +64,7 @@ set -euo pipefail
 if [ \$(id -u) -eq 0 ]; then
 	export PIPX_BIN_DIR=/usr/local/bin
 fi
-${TOOLS_PATH}/bin/pipx \$*
+${TOOLS_PATH}/bin/pipx "\$@"
 EOF
 chmod 755 /usr/local/bin/pipx
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -50,7 +50,7 @@ cmake --version
 swig -version
 sqlite3 --version
 pipx run nox --version
-pipx install nox
+pipx install --pip-args='--no-python-version-warning --no-input' nox
 nox --version
 
 # check libcrypt.so.1 can be loaded by some system packages,


### PR DESCRIPTION
The following command-line was not evaluated properly by the pipx wrapper:
`pipx install --pip-args='--no-python-version-warning --no-input' nox`

It errored out with  `pipx: error: unrecognized arguments: --no-input`

It's now handled correctly.
