### PR TITLE
Update to build against Python 3.10.0b4.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,7 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.9.6
 
 FROM build_cpython AS build_cpython310
 COPY build_scripts/cpython-pubkey-310-311.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0b3
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0b4
 
 
 FROM build_cpython AS all_python


### PR DESCRIPTION
See: https://www.python.org/downloads/release/python-3100b4/