### PR TITLE
chore: automake 1.16.3 → 1.16.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,8 +42,8 @@ RUN export AUTOCONF_ROOT=autoconf-2.71 && \
     manylinux-entrypoint /build_scripts/install-autoconf.sh
 
 COPY build_scripts/install-automake.sh /build_scripts/
-RUN export AUTOMAKE_ROOT=automake-1.16.3 && \
-    export AUTOMAKE_HASH=ce010788b51f64511a1e9bb2a1ec626037c6d0e7ede32c1c103611b9d3cba65f && \
+RUN export AUTOMAKE_ROOT=automake-1.16.4 && \
+    export AUTOMAKE_HASH=8a0f0be7aaae2efa3a68482af28e5872d8830b9813a6a932a2571eac63ca1794 && \
     export AUTOMAKE_DOWNLOAD_URL=http://ftp.gnu.org/gnu/automake && \
     manylinux-entrypoint /build_scripts/install-automake.sh
 


### PR DESCRIPTION
changelog: https://git.savannah.gnu.org/cgit/automake.git/tree/NEWS?h=v1.16.4