### PR TITLE
chore: bump pcre 8.44 → 8.45

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,8 +87,8 @@ COPY build_scripts/build-swig.sh /build_scripts/
 RUN export SWIG_ROOT=swig-4.0.2 && \
     export SWIG_HASH=d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc && \
     export SWIG_DOWNLOAD_URL=https://sourceforge.net/projects/swig/files/swig/${SWIG_ROOT} && \
-    export PCRE_ROOT=pcre-8.44 && \
-    export PCRE_HASH=aecafd4af3bd0f3935721af77b889d9024b2e01d96b58471bd91a3063fb47728 && \
+    export PCRE_ROOT=pcre-8.45 && \
+    export PCRE_HASH=4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09 && \
     export PCRE_DOWNLOAD_URL=https://ftp.pcre.org/pub/pcre && \
     manylinux-entrypoint /build_scripts/build-swig.sh
 


### PR DESCRIPTION
pcre 8.45 is the final release of PCRE1 c.f. https://www.pcre.org/original/changelog.txt
No need to add that to the update dependencies script until SWIG allows using PCRE2.