### PR TITLE
feat: add zlib-devel to runtime packages

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -14,7 +14,7 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 PYTHON_COMPILE_DEPS="zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel gpg libffi-devel"
 
 # Libraries that are allowed as part of the manylinux1 profile
-MANYLINUX1_DEPS="glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel  mesa-libGL-devel libICE-devel libSM-devel ncurses-devel"
+MANYLINUX1_DEPS="glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel  mesa-libGL-devel libICE-devel libSM-devel ncurses-devel zlib-devel"
 
 # Centos 5 is EOL and is no longer available from the usual mirrors, so switch
 # to http://vault.centos.org


### PR DESCRIPTION
With PEP600, more packages are now allowed by auditwheel policies for manylinux1/manylinux_2_5
 - libz.so.1