### PR TITLE
revert: go back to using Travis (when fixed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         policy: ["manylinux2014", "manylinux_2_24", "musllinux_1_1"]
-        platform: ["i686", "x86_64", "ppc64le"]
+        platform: ["i686", "x86_64"]
         include:
           - policy: "manylinux2010"
             platform: "i686"
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up emulation
-        if: matrix.platform == 'ppc64le'
+        if: matrix.platform != 'i686' && matrix.platform != 'x86_64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: ${{ matrix.platform }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,24 @@ jobs:
       env: POLICY="manylinux2014" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux2014" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="manylinux2014" PLATFORM="ppc64le" MANYLINUX_BUILD_FRONTEND="buildkit"
     - arch: arm64-graviton2
       virt: vm
       group: edge
       env: POLICY="manylinux_2_24" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux_2_24" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="manylinux_2_24" PLATFORM="ppc64le" MANYLINUX_BUILD_FRONTEND="buildkit"
     - arch: arm64-graviton2
       virt: vm
       group: edge
       env: POLICY="musllinux_1_1" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="musllinux_1_1" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="musllinux_1_1" PLATFORM="ppc64le" MANYLINUX_BUILD_FRONTEND="buildkit"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -23,7 +23,6 @@ OPENSSL_MIN_VERSION=1.1.1
 INSTALLED=$((openssl version | head -1 || test $? -eq 141) | awk '{ print $2 }')
 SMALLEST=$(echo -e "${INSTALLED}\n${OPENSSL_MIN_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1 || test $? -eq 141)
 
-# Ignore letters in version numbers
 if [ "${SMALLEST}" = "${OPENSSL_MIN_VERSION}" ]; then
 	echo "skipping installation of openssl ${OPENSSL_VERSION}, system provides openssl ${INSTALLED} which is newer than openssl ${OPENSSL_MIN_VERSION}"
 	exit 0


### PR DESCRIPTION
Replaces #1212 with a more limited rollback, keeping parts that are useful or could be useful in the future.
