### PR TITLE
fix: avoid broken lastversion

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -47,5 +47,5 @@ def update_python_tools(session):
 
 @nox.session(python="3.9", reuse_venv=True)
 def update_native_dependencies(session):
-    session.install("lastversion", "packaging", "requests")
+    session.install("lastversion!=1.6.0,!=2.0.0", "packaging", "requests")
     session.run("python", "update_native_dependencies.py", *session.posargs)


### PR DESCRIPTION
This will allow the update dependencies workflow to run again. See #1207.
