### PR TITLE
fix: change mirrors

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -23,7 +23,7 @@ MANYLINUX1_DEPS="glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-de
 # (5.11) can be referenced.
 sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
 sed -i 's/mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo
-sed -i 's/#\(baseurl.*\)mirror.centos.org\/centos\/$releasever/\1vault.centos.org\/5.11/' /etc/yum.repos.d/*.repo
+sed -i 's/#\(baseurl.*\)mirror.centos.org\/centos\/$releasever/\1archive.kernel.org\/centos-vault\/5.11/' /etc/yum.repos.d/*.repo
 
 # Get build utilities
 source $MY_DIR/build_utils.sh
@@ -52,9 +52,8 @@ rpm -Uvh --replacepkgs $MY_DIR/epel-release-5-4.noarch.rpm
 sed -i 's/\(mirrorlist=.*\)/\1\&protocol=http/g' /etc/yum.repos.d/epel*.repo
 
 # Dev toolset (for LLVM and other projects requiring C++11 support)
-# https://people.centos.org/tru/devtools-2/devtools-2.repo
+# http://linuxsoft.cern.ch/cern/devtoolset/slc5-devtoolset.repo
 cp $MY_DIR/devtools-2.repo /etc/yum.repos.d/
-sed -i 's/\<http\>/https/g' /etc/yum.repos.d/devtools-2.repo
 
 # Development tools and libraries
 yum -y install \

--- a/docker/build_scripts/devtools-2.repo
+++ b/docker/build_scripts/devtools-2.repo
@@ -1,5 +1,5 @@
 [testing-devtools-2-centos-$releasever]
-name=testing 2 devtools for CentOS $releasever 
-baseurl=http://people.centos.org/tru/devtools-2/$releasever/$basearch/RPMS
+name=testing 2 devtools for CentOS $releasever
+baseurl=http://linuxsoft.cern.ch/cern/devtoolset/slc5X/$basearch/yum/devtoolset/
 gpgcheck=0
 


### PR DESCRIPTION
vault.centos.org / people.centos.org now uses SSL with TLSv1 disabled which is not usable by CentOS 5 yum.
Move to http://archive.kernel.org/centos-vault / http://linuxsoft.cern.ch/cern/devtoolset.