### PR TITLE
ci: move ppc64le builds back to travis-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         policy: ["manylinux2014", "manylinux_2_24", "musllinux_1_1"]
-        platform: ["i686", "x86_64", "ppc64le"]
+        platform: ["i686", "x86_64"]
         include:
           - policy: "manylinux2010"
             platform: "i686"
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up emulation
-        if: matrix.platform == 'ppc64le'
+        if: matrix.platform != 'i686' && matrix.platform != 'x86_64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: ${{ matrix.platform }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,24 @@ jobs:
       env: POLICY="manylinux2014" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux2014" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="manylinux2014" PLATFORM="ppc64le"
     - arch: arm64-graviton2
       virt: vm
       group: edge
       env: POLICY="manylinux_2_24" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="manylinux_2_24" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="manylinux_2_24" PLATFORM="ppc64le"
     - arch: arm64-graviton2
       virt: vm
       group: edge
       env: POLICY="musllinux_1_1" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="musllinux_1_1" PLATFORM="s390x"
+    - arch: ppc64le
+      env: POLICY="musllinux_1_1" PLATFORM="ppc64le"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - COMMIT_SHA=${TRAVIS_COMMIT} ./build.sh
   - if [ -d "${HOME}/buildx-cache" ]; then rm -rf ${HOME}/buildx-cache; fi
   - mkdir ${HOME}/buildx-cache
-  - cp -rlf ./.buildx-cache-* ${HOME}/buildx-cache/
+  - if [ "${MANYLINUX_BUILD_FRONTEND}" != "docker" ]; then cp -rlf ./.buildx-cache-* ${HOME}/buildx-cache/; fi
 
 deploy:
   provider: script

--- a/build.sh
+++ b/build.sh
@@ -83,9 +83,13 @@ BUILD_ARGS_COMMON="
 	-f docker/Dockerfile docker/
 "
 
-# Force plain output on CI
 if [ "${CI:-}" == "true" ]; then
+	# Force plain output on CI
 	BUILD_ARGS_COMMON="--progress plain ${BUILD_ARGS_COMMON}"
+	# Workaround issue on ppc64le
+	if [ ${PLATFORM} == "ppc64le" ] && [ "${MANYLINUX_BUILD_FRONTEND}" == "docker" ]; then
+		BUILD_ARGS_COMMON="--network host ${BUILD_ARGS_COMMON}"
+	fi
 fi
 
 if [ "${MANYLINUX_BUILD_FRONTEND}" == "docker" ]; then

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -21,7 +21,7 @@ if [ "${MANYLINUX_BUILD_FRONTEND:-}" == "buildkit" ]; then
 	sudo apt-get update
 	sudo apt-get remove -y fuse ntfs-3g
 	sudo apt-get install -y --no-install-recommends runc containerd uidmap slirp4netns fuse-overlayfs
-	curl -fsSL "https://github.com/moby/buildkit/releases/download/v0.9.0/buildkit-v0.9.0.linux-${BUILDX_MACHINE}.tar.gz" | sudo tar -C /usr/local -xz
+	curl -fsSL "https://github.com/moby/buildkit/releases/download/v0.9.3/buildkit-v0.9.3.linux-${BUILDX_MACHINE}.tar.gz" | sudo tar -C /usr/local -xz
 	cat <<EOF > /tmp/start-buildkitd.sh
 buildkitd &> /dev/null &
 BUILDKITD_PID=\$!

--- a/travisci-install-buildx.sh
+++ b/travisci-install-buildx.sh
@@ -95,7 +95,7 @@ EOF
 	done
 fi
 mkdir -vp ~/.docker/cli-plugins/
-curl -sSL "https://github.com/docker/buildx/releases/download/v0.6.3/buildx-v0.6.3.linux-${BUILDX_MACHINE}" > ~/.docker/cli-plugins/docker-buildx
+curl -sSL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-${BUILDX_MACHINE}" > ~/.docker/cli-plugins/docker-buildx
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 docker buildx version
 


### PR DESCRIPTION
ppc64le travis-ci seems to be working with the docker-buildx frontend now. on both toronto & saopolo ppc64le workers.
Let's get those builds there (for now)  to remove slow qemu builds from GHA.
Keeping (for now) the (currently) unneeded bits for other frontends to ease future debugs. They've all been tested and work to some extent (depending on worker - saopolo or toronto, the docker one has no cache). I could add a commit to drop them and still be able to find them but don't want to skim through all commits if this is ever needed.