### PR TITLE
Add image for musllinux_1_2 policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        policy: ["manylinux2014", "manylinux_2_24", "musllinux_1_1"]
+        policy: ["manylinux2014", "manylinux_2_24", "musllinux_1_1", "musllinux_1_2"]
         platform: ["i686", "x86_64", "ppc64le"]
         include:
           - policy: "manylinux2010"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ jobs:
       env: POLICY="musllinux_1_1" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="musllinux_1_1" PLATFORM="s390x"
+    - arch: arm64-graviton2
+      virt: vm
+      group: edge
+      env: POLICY="musllinux_1_2" PLATFORM="aarch64"
+    - arch: s390x
+      env: POLICY="musllinux_1_2" PLATFORM="s390x"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,11 @@ elif [ "${POLICY}" == "musllinux_1_1" ]; then
 	DEVTOOLSET_ROOTPATH=
 	PREPEND_PATH=
 	LD_LIBRARY_PATH_ARG=
+elif [ "${POLICY}" == "musllinux_1_2" ]; then
+	BASEIMAGE="${MULTIARCH_PREFIX}alpine:3.14"
+	DEVTOOLSET_ROOTPATH=
+	PREPEND_PATH=
+	LD_LIBRARY_PATH_ARG=
 else
 	echo "Unsupported policy: '${POLICY}'"
 	exit 1

--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -7,12 +7,12 @@ set -exuo pipefail
 # Get script directory
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-if [ "${POLICY}" == "musllinux_1_1" ]; then
-	export NO_REGEX=NeedsStartEnd
-fi
-
 # Get build utilities
 source $MY_DIR/build_utils.sh
+
+if [ "${BASE_POLICY}" == "musllinux" ]; then
+	export NO_REGEX=NeedsStartEnd
+fi
 
 # Install newest libtool
 check_var ${GIT_ROOT}

--- a/docker/build_scripts/install-build-packages.sh
+++ b/docker/build_scripts/install-build-packages.sh
@@ -19,7 +19,7 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == 
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	PACKAGE_MANAGER=apt
 	COMPILE_DEPS="libbz2-dev libncurses5-dev libreadline-dev tk-dev libgdbm-dev libdb-dev libpcap-dev liblzma-dev openssl libssl-dev libkeyutils-dev libkrb5-dev comerr-dev libidn2-0-dev libcurl4-openssl-dev uuid-dev libffi-dev linux-kernel-headers"
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
 	PACKAGE_MANAGER=apk
 	COMPILE_DEPS="bzip2-dev ncurses-dev readline-dev tk-dev gdbm-dev libpcap-dev xz-dev openssl openssl-dev keyutils-dev krb5-dev libcom_err libidn-dev curl-dev util-linux-dev libffi-dev linux-headers"
 else

--- a/docker/build_scripts/install-entrypoint.sh
+++ b/docker/build_scripts/install-entrypoint.sh
@@ -23,6 +23,6 @@ if [ "${AUDITWHEEL_PLAT}" = "manylinux2010_i686" ] || [ "${AUDITWHEEL_PLAT}" = "
 	LC_ALL=C "${MY_DIR}/update-system-packages.sh"
 fi
 
-if [ "${AUDITWHEEL_POLICY}" = "musllinux_1_1" ]; then
+if [ "${AUDITWHEEL_POLICY}" = "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" = "musllinux_1_2" ]; then
 	apk add --no-cache bash
 fi

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -36,7 +36,7 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == 
 	MANYLINUX_DEPS="glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel mesa-libGL-devel libICE-devel libSM-devel zlib-devel expat-devel"
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	MANYLINUX_DEPS="libc6-dev libstdc++-6-dev libglib2.0-dev libx11-dev libxext-dev libxrender-dev libgl1-mesa-dev libice-dev libsm-dev libz-dev libexpat1-dev"
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
 	MANYLINUX_DEPS="musl-dev libstdc++ glib-dev libx11-dev libxext-dev libxrender-dev mesa-dev libice-dev libsm-dev zlib-dev expat-dev"
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"
@@ -53,8 +53,8 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == 
 	fi
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	RUNTIME_DEPS="zlib1g libbz2-1.0 libexpat1 libncurses5 libreadline7 tk libgdbm3 libdb5.3 libpcap0.8 liblzma5 libssl1.1 libkeyutils1 libkrb5-3 libcomerr2 libidn2-0 libcurl3 uuid libffi6"
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
-	RUNTIME_DEPS="zlib bzip2 expat ncurses5-libs readline tk gdbm db xz openssl keyutils-libs krb5-libs libcom_err libidn2 libcurl libuuid libffi"
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
+	RUNTIME_DEPS="zlib bzip2 expat ncurses-libs readline tk gdbm db xz openssl keyutils-libs krb5-libs libcom_err libidn2 libcurl libuuid libffi"
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"
 	exit 1
@@ -120,7 +120,7 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	apt-get upgrade -qq -y
 	apt-get install -qq -y --no-install-recommends ca-certificates gpg curl locales
 	TOOLCHAIN_DEPS="binutils gcc g++ gfortran"
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
 	TOOLCHAIN_DEPS="binutils gcc g++ gfortran"
 	BASETOOLS="${BASETOOLS} curl util-linux"
 	PACKAGE_MANAGER=apk

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -54,7 +54,12 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == 
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	RUNTIME_DEPS="zlib1g libbz2-1.0 libexpat1 libncurses5 libreadline7 tk libgdbm3 libdb5.3 libpcap0.8 liblzma5 libssl1.1 libkeyutils1 libkrb5-3 libcomerr2 libidn2-0 libcurl3 uuid libffi6"
 elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
-	RUNTIME_DEPS="zlib bzip2 expat ncurses-libs readline tk gdbm db xz openssl keyutils-libs krb5-libs libcom_err libidn2 libcurl libuuid libffi"
+	RUNTIME_DEPS="zlib bzip2 expat readline tk gdbm db xz openssl keyutils-libs krb5-libs libcom_err libidn2 libcurl libuuid libffi"
+	if [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+		RUNTIME_DEPS="${RUNTIME_DEPS} ncurses5-libs"
+	else
+		RUNTIME_DEPS="${RUNTIME_DEPS} ncurses-libs"
+	fi
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"
 	exit 1

--- a/docker/build_scripts/update-system-packages.sh
+++ b/docker/build_scripts/update-system-packages.sh
@@ -33,7 +33,7 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 		find /etc/ssl/certs -name 'DST_Root_CA_X3.pem' -delete
 		update-ca-certificates
 	fi
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
 	apk upgrade --no-cache
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,7 +12,7 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	export DEBIAN_FRONTEND=noninteractive
 	PACKAGE_MANAGER=apt
 	apt-get update -qq
-elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
+elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
 	PACKAGE_MANAGER=apk
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"


### PR DESCRIPTION
Added a musllinux_1_2 policy

This is more of an Alpine thing than musl.
Some wheels built with musllinux_1_1 (Alpine 3.12) don't work on Alpine 3.14+ due to https://git.alpinelinux.org/aports/tree/main/python3/bpo-43112.patch?h=v3.14.2

On that same note there is https://github.com/python/cpython/pull/24502