### PR TITLE
chore(manylinux1): use PyPI patchelf rather than rebuilding from source

### DIFF
--- a/docker/build_scripts/build.sh
+++ b/docker/build_scripts/build.sh
@@ -139,6 +139,8 @@ pip install -U --require-hashes -r $MY_DIR/requirements-tools.txt
 
 # Make auditwheel available in PATH
 ln -s $TOOLS_PATH/bin/auditwheel /usr/local/bin/auditwheel
+# Make patchelf available in PATH
+ln -s $TOOLS_PATH/bin/patchelf /usr/local/bin/patchelf
 # Make pipx available in PATH,
 # Make sure when root installs apps, they're also in the PATH
 cat <<EOF > /usr/local/bin/pipx
@@ -166,9 +168,6 @@ deactivate
 
 # Now we can delete our built OpenSSL headers/static libs since we've linked everything we need
 rm -rf /usr/local/ssl
-
-# Install patchelf (latest with unreleased bug fixes) and apply our patches
-build_patchelf $PATCHELF_VERSION $PATCHELF_HASH
 
 # Clean up development headers and other unnecessary stuff for
 # final image

--- a/docker/build_scripts/build_env.sh
+++ b/docker/build_scripts/build_env.sh
@@ -15,10 +15,6 @@ OPENSSL_ROOT=openssl-1.1.1l
 OPENSSL_HASH=0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
 OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source
 
-PATCHELF_VERSION=0.13.1
-PATCHELF_HASH=f6d5ecdb51ad78e963233cfde15020f9eebc9d9c7c747aaed54ce39c284ad019
-PATCHELF_DOWNLOAD_URL=https://github.com/NixOS/patchelf/archive
-
 CURL_ROOT=curl-7.80.0
 CURL_HASH=dab997c9b08cb4a636a03f2f7f985eaba33279c1c52692430018fae4a4878dc7
 CURL_DOWNLOAD_URL=https://curl.haxx.se/download

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -296,16 +296,3 @@ function build_libxcrypt {
     rm -rf /usr/include/crypt.h
     rm -rf /usr/lib*/libcrypt.a /usr/lib*/libcrypt.so /usr/lib*/libcrypt.so.1
 }
-
-function build_patchelf {
-    local patchelf_version=$1
-    local patchelf_hash=$2
-    check_var ${patchelf_version}
-    check_var ${patchelf_hash}
-    check_var ${PATCHELF_DOWNLOAD_URL}
-    fetch_source ${patchelf_version}.tar.gz ${PATCHELF_DOWNLOAD_URL}
-    check_sha256sum ${patchelf_version}.tar.gz $patchelf_hash
-    tar -xzf ${patchelf_version}.tar.gz
-    (cd patchelf-$patchelf_version && ./bootstrap.sh && do_standard_install)
-    rm -rf ${patchelf_version}.tar.gz patchelf-$patchelf_version
-}

--- a/docker/build_scripts/requirements-tools.txt
+++ b/docker/build_scripts/requirements-tools.txt
@@ -24,6 +24,14 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via pipx
+patchelf==0.14.3.0 \
+    --hash=sha256:04cdeea7b24d8daca78e885a113791cedb278eb164a1760c509702d6ed155a46 \
+    --hash=sha256:09ad55d9dff020ecab75d02ae592b6ff7997fc0428ce7ffb35213b3fdd79dad7 \
+    --hash=sha256:0c778f7af59bd781d187ea27556a1ad3e0dd044d85c77536a7c9d2cc027ff0fc \
+    --hash=sha256:4b3ee96c6ac9b2059f038db2838bc0be4d119d3b5b8b0cc252e5cadd832a5ae5 \
+    --hash=sha256:a8dd89901f32f0ce93a5c995a8f9eb79908d43e3a70eaf6b8efe8643976e6a8c \
+    --hash=sha256:fa208aee4b0e6b3f4dbd1bb2be82b1d2635e045e7dfe227b2095bb2e3db67811
+    # via -r requirements-tools.in
 pipx==0.16.4 \
     --hash=sha256:992e78082c0b33c7bc708176ce9e0df9bac9ae3b08bf111c368571bc32e723d6 \
     --hash=sha256:e207e1b1a9014bdb0c484b974381fc5a96729685dba91355888372172d1e3264

--- a/requirements-tools.in
+++ b/requirements-tools.in
@@ -1,3 +1,4 @@
 auditwheel
 certifi
+patchelf
 pipx

--- a/update_native_dependencies.py
+++ b/update_native_dependencies.py
@@ -121,11 +121,7 @@ def _update_sqlite(dry_run):
 
 def _update_with_gh(tool, dry_run):
     repo = {
-        "patchelf": "NixOS/patchelf",
         "libxcrypt": "besser82/libxcrypt",
-    }
-    major = {
-        "patchelf": "0.13"
     }
     build_env = Path(__file__).parent / "docker" / "build_scripts" / "build_env.sh"
     lines = build_env.read_text().splitlines()
@@ -135,7 +131,7 @@ def _update_with_gh(tool, dry_run):
         if match is None:
             continue
         current_version = Version(match["version"])
-        latest_tag = latest(repo[tool], output_format="tag", major=major.get(tool, None))
+        latest_tag = latest(repo[tool], output_format="tag")
         latest_version = Version(latest_tag)
         if latest_version > current_version:
             url = re.match(f"^{tool.upper()}_DOWNLOAD_URL=(?P<url>\\S+)$", lines[i + 2])["url"]
@@ -158,7 +154,7 @@ def main():
     _update_sqlite(args.dry_run)
     for tool in ["autoconf", "automake", "curl", "libtool", "git", "swig", "openssl"]:
         _update_with_root(tool, args.dry_run)
-    for tool in ["patchelf", "libxcrypt"]:
+    for tool in ["libxcrypt"]:
         _update_with_gh(tool, args.dry_run)
 
 


### PR DESCRIPTION
patchelf 0.14+ requires c++17
c++17 is not available on manylinux1 images, use a prebuilt patchelf wheel for installation.

c.f. #1236 description for the reason for draft.