### PR TITLE
Add support for Pyston 2.3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ Image content
 
 All images currently contain:
 
-- CPython 3.6, 3.7, 3.8, 3.9, 3.10, and PyPy 3.7, 3.8 installed in
+- CPython 3.6, 3.7, 3.8, 3.9, 3.10, and PyPy 3.7, 3.8 and Pyston 2.3 installed in
   ``/opt/python/<python tag>-<abi tag>``. The directories are named
   after the PEP 425 tags for each environment --
   e.g. ``/opt/python/cp37-cp37m`` contains a CPython 3.7 build, and
@@ -167,6 +167,8 @@ became useless (builds with and without pymalloc are ABI compatible) and so has
 been removed. (e.g. ``/opt/python/cp38-cp38``)
 
 Note that PyPy is not available on ppc64le & s390x.
+
+Note that Pyston is only available on x86_64.
 
 Building Docker images
 ----------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,8 +143,11 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.0
 FROM build_cpython AS all_python
 COPY build_scripts/install-pypy.sh /build_scripts/install-pypy.sh
 COPY build_scripts/pypy.sha256 /build_scripts/pypy.sha256
+COPY build_scripts/install-pyston.sh /build_scripts/install-pyston.sh
+COPY build_scripts/pyston.sha256 /build_scripts/pyston.sha256
 RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.7 7.3.7
 RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.8 7.3.7
+RUN manylinux-entrypoint /build_scripts/install-pyston.sh 3.8 2.3.1
 COPY --from=build_cpython36 /opt/_internal /opt/_internal/
 COPY --from=build_cpython37 /opt/_internal /opt/_internal/
 COPY --from=build_cpython38 /opt/_internal /opt/_internal/

--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -10,7 +10,7 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/build_utils.sh
 
 mkdir /opt/python
-for PREFIX in $(find /opt/_internal/ -mindepth 1 -maxdepth 1 \( -name 'cpython*' -o -name 'pypy*' \)); do
+for PREFIX in $(find /opt/_internal/ -mindepth 1 -maxdepth 1 \( -name 'cpython*' -o -name 'pypy*' -o -name 'pyston*' \)); do
 	# Some python's install as bin/python3. Make them available as
 	# bin/python.
 	if [ -e ${PREFIX}/bin/python3 ] && [ ! -e ${PREFIX}/bin/python ]; then
@@ -30,6 +30,8 @@ for PREFIX in $(find /opt/_internal/ -mindepth 1 -maxdepth 1 \( -name 'cpython*'
 	# Make versioned python commands available directly in environment.
 	if [[ "${PREFIX}" == *"/pypy"* ]]; then
 		ln -s ${PREFIX}/bin/python /usr/local/bin/pypy${PY_VER}
+	elif [[ "${PREFIX}" == *"/pyston"* ]]; then
+		ln -s ${PREFIX}/bin/python /usr/local/bin/pyston${PY_VER}
 	else
 		ln -s ${PREFIX}/bin/python /usr/local/bin/python${PY_VER}
 	fi

--- a/docker/build_scripts/install-pyston.sh
+++ b/docker/build_scripts/install-pyston.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+source $MY_DIR/build_utils.sh
+
+if [ "${BASE_POLICY}" == "musllinux" ]; then
+	echo "Skip Pyston build on musllinux"
+	exit 0
+elif [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ]; then
+	echo "Skip Pyston build on manylinux2010 - glibc is too old"
+	exit 0
+fi
+
+PYTHON_VERSION=$1
+PYSTON_VERSION=$2
+PYSTON_DOWNLOAD_URL=https://github.com/pyston/pyston/releases/download/pyston_${PYSTON_VERSION}
+
+
+function get_shortdir {
+	local exe=$1
+	$exe -c 'import sys; print("pyston%d.%d-%d.%d.%d" % (sys.version_info[:2]+sys.pyston_version_info[:3]))'
+}
+
+
+mkdir -p /tmp
+cd /tmp
+
+case ${AUDITWHEEL_ARCH} in
+	x86_64) PYSTON_ARCH=linux64;;
+	*) echo "No Pyston for ${AUDITWHEEL_ARCH}"; exit 0;;
+esac
+
+# in v2.3.1 the pyston team found a bug in the portable release package and had to upload a new version with suffix _v2
+PYSTON_TARBALL_VERSION=
+case ${PYSTON_VERSION} in
+	2.3.1) PYSTON_TARBALL_VERSION=_v2;;
+	*);;
+esac
+
+TARBALL=pyston_${PYSTON_VERSION}_portable${PYSTON_TARBALL_VERSION}.tar.gz
+TMPDIR=/tmp/pyston_${PYSTON_VERSION}
+PREFIX="/opt/_internal"
+
+mkdir -p ${PREFIX}
+
+fetch_source ${TARBALL} ${PYSTON_DOWNLOAD_URL}
+
+# We only want to check the current tarball sha256sum
+grep " ${TARBALL}\$" ${MY_DIR}/pyston.sha256 > ${TARBALL}.sha256
+# then check sha256 sum
+sha256sum -c ${TARBALL}.sha256
+
+tar -xf ${TARBALL}
+
+# rename the directory to something shorter like pyston3.8-2.3.1
+PREFIX=${PREFIX}/$(get_shortdir ${TMPDIR}/bin/pyston)
+mv ${TMPDIR} ${PREFIX}
+
+# add a generic "python" symlink
+if [ ! -f "${PREFIX}/bin/python" ]; then
+	ln -s pyston ${PREFIX}/bin/python
+fi
+
+# We do not need the Python test suites
+find ${PREFIX} -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf
+
+# Remove pip because Pystons bundled pip does not create 'pip' and 'pip3'
+# finalize.sh will run ensurepip to install it correctly
+${PREFIX}/bin/pyston -m pip uninstall -y pip
+
+# We do not need precompiled .pyc and .pyo files.
+clean_pyc ${PREFIX}

--- a/docker/build_scripts/pyston.sha256
+++ b/docker/build_scripts/pyston.sha256
@@ -1,0 +1,1 @@
+4e16df1eaf5f226c0629f2db1e63033454c94cb9e29f50154177819662df5b15  pyston_2.3.1_portable_v2.tar.gz

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -30,6 +30,8 @@ for PYTHON in /opt/python/*/bin/python; do
 	PYVERS=$(${PYTHON} -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 	if [ "${IMPLEMENTATION}" == "pypy" ]; then
 		LINK_PREFIX=pypy
+	elif [ "${IMPLEMENTATION}" == "pyston" ]; then
+		LINK_PREFIX=pyston
 	else
 		LINK_PREFIX=python
 		# Make sure sqlite3 module can be loaded properly and is the manylinux version one


### PR DESCRIPTION
This commit integrates [Pyston](https://github.com/pyston/pyston) into manylinux.
While Pyston 2.x is based on CPython 3.8 it's not ABI compatible so recompiling of binary extensions is required. Providing precompiled pip installable packages would greatly help our users.

- Pyston currently only runs on `x86_64`
- gets installed into `/opt/python/pyston38-pyston_23_x86_64_linux_gnu` ->
  `/opt/_internal/pyston3.8-2.3.1`
- `manylinux2014` & `manylinux_2_24` supported
- EOL `manylinux2010` isn't supported because the supplied glibc is too old for Pyston
- `musllinux` is not supported

With this changes and the my WIP changes to [cibuildwheel](https://github.com/undingen/cibuildwheel/tree/pyston_2.3.1) I was able to generate wheels for Pyston.

Notes:
- Please very carefully review my PR because this is the first time I'm working with manylinux.
- Patch is mainly copied from the script for PyPy.
- We don't have a [PEP425](https://www.python.org/dev/peps/pep-0425/) Python Tag yet.
- Compiling Pyston is not really feasible because it takes many hours and is only supported on Ubuntu and has quite a few additional dependencies that's why I'm using the binary package.
