### PR TITLE
Keep libpython static libraries in compressed form

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -135,8 +135,10 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.10.1
 
 
 FROM build_cpython AS all_python
-COPY build_scripts/install-pypy.sh /build_scripts/install-pypy.sh
-COPY build_scripts/pypy.sha256 /build_scripts/pypy.sha256
+COPY build_scripts/install-pypy.sh \
+     build_scripts/pypy.sha256 \
+     build_scripts/finalize-python.sh \
+     /build_scripts/
 RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.7 7.3.7
 RUN manylinux-entrypoint /build_scripts/install-pypy.sh 3.8 7.3.7
 COPY --from=build_cpython36 /opt/_internal /opt/_internal/
@@ -144,7 +146,7 @@ COPY --from=build_cpython37 /opt/_internal /opt/_internal/
 COPY --from=build_cpython38 /opt/_internal /opt/_internal/
 COPY --from=build_cpython39 /opt/_internal /opt/_internal/
 COPY --from=build_cpython310 /opt/_internal /opt/_internal/
-RUN hardlink -cv /opt/_internal
+RUN manylinux-entrypoint /build_scripts/finalize-python.sh
 
 
 FROM runtime_base

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -55,9 +55,6 @@ fi
 popd
 rm -rf Python-${CPYTHON_VERSION} Python-${CPYTHON_VERSION}.tgz Python-${CPYTHON_VERSION}.tgz.asc
 
-# we don't need libpython*.a, and they're many megabytes
-find ${PREFIX} -name '*.a' -print0 | xargs -0 rm -f
-
 # We do not need precompiled .pyc and .pyo files.
 clean_pyc ${PREFIX}
 

--- a/docker/build_scripts/finalize-python.sh
+++ b/docker/build_scripts/finalize-python.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# most people don't need libpython*.a, and they're many megabytes.
+# compress them all together for best efficiency
+pushd /opt/_internal
+XZ_OPT=-9e tar -cJf static-libs-for-embedding-only.tar.xz cpython-*/lib/libpython*.a
+popd
+find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
+
+hardlink -cv /opt/_internal


### PR DESCRIPTION
At present, libpythonX.Y.a files are being deleted from the image after the build.  This is a large inconvenience for applications that need it in order to embed the Python interpreter or create a frozen application.  See #91, #793, #255, #30 for use cases.

There are good reasons against including these libraries:
1. The .a files are many megabytes in size each, adding bloat to the images.
2. Broken build systems may link with libpython inadvertently when building extension modules.
3. Users who are not aware that they shouldn't link with libpython for extensions will see libpython and try to link with it.

This PR mitigates all these concerns by compressing all of them into an XZ-compressed tarball:
1. This allows the compression to use a single dictionary, greatly reducing the size.
2. They cannot be found automatically by a linker or build system.
3. They will not show up in operations like `find | grep libpython`

At the same time, it allows developers who know what they are doing to get access to them using a single `tar` command.

The total increase in image size, measured for manylinux2014_x86_64, is 3.1 MiB.  This represents an increase of 0.28 %, lower than the 0.5 % threshold for acceptance established by @mayeut in #91.  I also measured it for manylinux2010_x86_64, the increase there is 0.31 %.

Thank you so much for your consideration!

Fixes #91