### PR TITLE
Added position independent code flag for python compilation.

### DIFF
--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -6,8 +6,8 @@
 # other flags mentioned in https://wiki.ubuntu.com/ToolChain/CompilerFlags can't be
 # used because the distros used here are too old
 MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
-MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
-MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC"
+MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC"
 MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
 
 export BASE_POLICY=manylinux


### PR DESCRIPTION
In using the manylinux image to create wheels, the package I am compiling creates a shared library from the static python libraries in the image. Without the position independent code flag (-fPIC) I get the following error:
```
 /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: buck-out/gen/third-party/python/python3.8_lib/libpython3.8.a(myreadline.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used    when making a shared object; recompile with -fPIC
 /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: final link failed: nonrepresentable section on output
 collect2: error: ld returned 1 exit status
```
Adding the flag fixes this compilation issue. Since, as noted in https://github.com/pypa/manylinux/pull/1250, the static libs remain in compressed form unless explicitly unpacked, this should have minimal affect on most users.