### PR TITLE
Add ability to apply patches for CPython

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,7 +107,11 @@ RUN export OPENSSL_ROOT=openssl-1.1.1m && \
     manylinux-entrypoint /build_scripts/build-openssl.sh
 
 COPY build_scripts/build-cpython.sh /build_scripts/
+COPY build_scripts/maybe-patch-cpython.sh /build_scripts/
+COPY build_scripts/cpython-patches /build_scripts/cpython-patches
 
+# We should grant exec perrmission because it will be called not from Dockerfile
+RUN chmod +x /build_scripts/maybe-patch-cpython.sh
 
 FROM build_cpython AS build_cpython36
 COPY build_scripts/cpython-pubkeys.txt /build_scripts/cpython-pubkeys.txt

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -30,6 +30,9 @@ fetch_source Python-${CPYTHON_VERSION}.tgz.asc ${CPYTHON_DOWNLOAD_URL}/${CPYTHON
 gpg --import ${MY_DIR}/cpython-pubkeys.txt
 gpg --verify Python-${CPYTHON_VERSION}.tgz.asc
 tar -xzf Python-${CPYTHON_VERSION}.tgz
+if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
+  manylinux-entrypoint $MY_DIR/maybe-patch-cpython.sh ${CPYTHON_VERSION}
+fi
 pushd Python-${CPYTHON_VERSION}
 PREFIX="/opt/_internal/cpython-${CPYTHON_VERSION}"
 mkdir -p ${PREFIX}/lib

--- a/docker/build_scripts/cpython-patches/bpo-44751-cp36.diff
+++ b/docker/build_scripts/cpython-patches/bpo-44751-cp36.diff
@@ -1,0 +1,24 @@
+--- Include/Python.h
++++ Include/Python.h
+@@ -35,9 +35,6 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_CRYPT_H
+-#include <crypt.h>
+-#endif
+
+ /* For size_t? */
+ #ifdef HAVE_STDDEF_H
+--- Modules/_cryptmodule.c
++++ Modules/_cryptmodule.c
+@@ -4,6 +4,9 @@
+ #include "Python.h"
+
+ #include <sys/types.h>
++#ifdef HAVE_CRYPT_H
++#include <crypt.h>
++#endif
+
+ /* Module crypt */
+

--- a/docker/build_scripts/cpython-patches/bpo-44751-cp37.diff
+++ b/docker/build_scripts/cpython-patches/bpo-44751-cp37.diff
@@ -1,0 +1,34 @@
+--- Include/Python.h
++++ Include/Python.h
+@@ -35,19 +35,6 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_CRYPT_H
+-#if defined(HAVE_CRYPT_R) && !defined(_GNU_SOURCE)
+-/* Required for glibc to expose the crypt_r() function prototype. */
+-#  define _GNU_SOURCE
+-#  define _Py_GNU_SOURCE_FOR_CRYPT
+-#endif
+-#include <crypt.h>
+-#ifdef _Py_GNU_SOURCE_FOR_CRYPT
+-/* Don't leak the _GNU_SOURCE define to other headers. */
+-#  undef _GNU_SOURCE
+-#  undef _Py_GNU_SOURCE_FOR_CRYPT
+-#endif
+-#endif
+
+ /* For size_t? */
+ #ifdef HAVE_STDDEF_H
+--- Modules/_cryptmodule.c
++++ Modules/_cryptmodule.c
+@@ -4,6 +4,9 @@
+ #include "Python.h"
+
+ #include <sys/types.h>
++#ifdef HAVE_CRYPT_H
++#include <crypt.h>
++#endif
+
+ /* Module crypt */
+

--- a/docker/build_scripts/cpython-patches/bpo-44751-cp38.diff
+++ b/docker/build_scripts/cpython-patches/bpo-44751-cp38.diff
@@ -1,0 +1,34 @@
+--- Include/Python.h
++++ Include/Python.h
+@@ -35,19 +35,6 @@
+ #ifndef MS_WINDOWS
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_CRYPT_H
+-#if defined(HAVE_CRYPT_R) && !defined(_GNU_SOURCE)
+-/* Required for glibc to expose the crypt_r() function prototype. */
+-#  define _GNU_SOURCE
+-#  define _Py_GNU_SOURCE_FOR_CRYPT
+-#endif
+-#include <crypt.h>
+-#ifdef _Py_GNU_SOURCE_FOR_CRYPT
+-/* Don't leak the _GNU_SOURCE define to other headers. */
+-#  undef _GNU_SOURCE
+-#  undef _Py_GNU_SOURCE_FOR_CRYPT
+-#endif
+-#endif
+
+ /* For size_t? */
+ #ifdef HAVE_STDDEF_H
+--- Modules/_cryptmodule.c
++++ Modules/_cryptmodule.c
+@@ -4,6 +4,9 @@
+ #include "Python.h"
+
+ #include <sys/types.h>
++#ifdef HAVE_CRYPT_H
++#include <crypt.h>
++#endif
+
+ /* Module crypt */
+

--- a/docker/build_scripts/maybe-patch-cpython.sh
+++ b/docker/build_scripts/maybe-patch-cpython.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Patch applying script called from build-cpython.sh
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+PATCHES_DIR=$MY_DIR/cpython-patches
+
+CPYTHON_VERSION=$1
+CPYTHON_SRC_DIR=Python-${CPYTHON_VERSION}
+
+if [[ "${CPYTHON_VERSION}" == 3.6* ]]; then
+  patch -s -p0 -d "${CPYTHON_SRC_DIR}" < $PATCHES_DIR/bpo-44751-cp36.diff
+fi
+
+if [[ "${CPYTHON_VERSION}" == 3.7* ]]; then
+  patch -s -p0 -d "${CPYTHON_SRC_DIR}" < $PATCHES_DIR/bpo-44751-cp37.diff
+fi
+
+if [[ "${CPYTHON_VERSION}" == 3.8* ]]; then
+  patch -s -p0 -d "${CPYTHON_SRC_DIR}" < $PATCHES_DIR/bpo-44751-cp38.diff
+fi


### PR DESCRIPTION
close #1264

Key notes:
- patches was generated via `diff -Naur` with hand edits (for example I deleted timestamps) 
- patches applied only for `manylinux_2_24` images
- patches stored in separated folder
- patches applied silently
- to control patch applying `maybe-patch-cpython.sh` script was created. It allows control which patches should be applied by CPython version 
- there is only `bpo-44751` patch for cp36, cp37 and cp38 for now

Also I deploy patched images for easy tests (and my usage in pet-project) here: https://quay.io/organization/pypa_patched