### PR TITLE
fix: ignore `SIGPIPE` in previous piped command when `head -1` exits

### DIFF
--- a/docker/build_scripts/install-autoconf.sh
+++ b/docker/build_scripts/install-autoconf.sh
@@ -18,8 +18,10 @@ check_var ${AUTOCONF_DOWNLOAD_URL}
 
 AUTOCONF_VERSION=${AUTOCONF_ROOT#*-}
 if autoconf --version > /dev/null 2>&1; then
-	INSTALLED=$(autoconf --version | head -1 | awk '{ print $NF }')
-	SMALLEST=$(echo -e "${INSTALLED}\n${AUTOCONF_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1)
+	# || test $? -eq 141 is there to ignore SIGPIPE with set -o pipefail
+	# c.f. https://stackoverflow.com/questions/22464786/ignoring-bash-pipefail-for-error-code-141#comment60412687_33026977
+	INSTALLED=$((autoconf --version | head -1 || test $? -eq 141) | awk '{ print $NF }')
+	SMALLEST=$(echo -e "${INSTALLED}\n${AUTOCONF_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1 || test $? -eq 141)
 	if [ "${SMALLEST}" == "${AUTOCONF_VERSION}" ]; then
 		echo "skipping installation of autoconf ${AUTOCONF_VERSION}, system provides autoconf ${INSTALLED}"
 		exit 0

--- a/docker/build_scripts/install-automake.sh
+++ b/docker/build_scripts/install-automake.sh
@@ -17,8 +17,10 @@ check_var ${AUTOMAKE_DOWNLOAD_URL}
 
 AUTOMAKE_VERSION=${AUTOMAKE_ROOT#*-}
 if automake --version > /dev/null 2>&1; then
-	INSTALLED=$(automake --version | head -1 | awk '{ print $NF }')
-	SMALLEST=$(echo -e "${INSTALLED}\n${AUTOMAKE_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1)
+	# || test $? -eq 141 is there to ignore SIGPIPE with set -o pipefail
+	# c.f. https://stackoverflow.com/questions/22464786/ignoring-bash-pipefail-for-error-code-141#comment60412687_33026977
+	INSTALLED=$((automake --version | head -1 || test $? -eq 141) | awk '{ print $NF }')
+	SMALLEST=$(echo -e "${INSTALLED}\n${AUTOMAKE_VERSION}" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -1 || test $? -eq 141)
 	if [ "${SMALLEST}" == "${AUTOMAKE_VERSION}" ]; then
 		echo "skipping installation of automake ${AUTOMAKE_VERSION}, system provides automake ${INSTALLED}"
 		exit 0


### PR DESCRIPTION
These errors show up now & then in CI. This was corrected for OpenSSL build in 1a8f66dc16718b63459c08ea424f4a2d1c95639f  but not for autoconf & automake.