### PR TITLE
fix: invalid environment variable used

### DIFF
--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -10,11 +10,11 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 # Get build utilities
 source $MY_DIR/build_utils.sh
 
-if [ "${POLICY}" == "musllinux_1_1" ]; then
+if [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
 	export NO_REGEX=NeedsStartEnd
 fi
 
-if [ "${POLICY}" == "manylinux2010" ] || [ "${POLICY}" == "manylinux2014" ] || [ "${POLICY}" == "manylinux_2_24" ]; then
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	export NO_UNCOMPRESS2=1
 fi
 

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -11,7 +11,7 @@ MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong
 MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
 
 export BASE_POLICY=manylinux
-if [ "${POLICY:0:9}" == "musllinux" ]; then
+if [ "${AUDITWHEEL_POLICY:0:9}" == "musllinux" ]; then
 	export BASE_POLICY=musllinux
 fi
 


### PR DESCRIPTION
While investigating #1222, I found out that some build backends did not forward build args as environment variables so only use those explicitly exposed as environment variables in the scripts.