### PR TITLE
feature: add manylinux_2_28 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
             platform: "i686"
           - policy: "manylinux2010"
             platform: "x86_64"
+          - policy: "manylinux_2_28"
+            platform: "x86_64"
 
     env:
       POLICY: ${{ matrix.policy }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,12 @@ jobs:
     - arch: arm64-graviton2
       virt: vm
       group: edge
+      env: POLICY="manylinux_2_28" PLATFORM="aarch64"
+    - arch: ppc64le
+      env: POLICY="manylinux_2_28" PLATFORM="ppc64le"
+    - arch: arm64-graviton2
+      virt: vm
+      group: edge
       env: POLICY="musllinux_1_1" PLATFORM="aarch64"
     - arch: s390x
       env: POLICY="musllinux_1_1" PLATFORM="s390x"

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,11 @@ on June 30th, 2024.
 
 PEP 600 has been designed to be "future-proof" and does not enforce specific symbols and a specific distro to build.
 It only states that a wheel tagged ``manylinux_x_y`` shall work on any distro based on ``glibc>=x.y``.
-The manylinux project supports ``manylinux_2_24`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
+The manylinux project supports:
+
+- ``manylinux_2_24`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
+
+- ``manylinux_2_28`` images for ``x86_64``, ``aarch64`` and ``ppc64le``.
 
 
 Wheel packages compliant with those tags can be uploaded to
@@ -55,8 +59,9 @@ pip:
 | ``manylinux`` tag | Client-side pip  | CPython (sources) version  | Distribution default pip compatibility    |
 |                   | version required | embedding a compatible pip |                                           |
 +===================+==================+============================+===========================================+
-| ``manylinux_x_y`` | pip >= 20.3      | 3.8.10+, 3.9.5+, 3.10.0+   | ALT Linux 10+, Debian 11+, Fedora 34+,    |
-|                   |                  |                            | Mageia 8+, Photon OS 3.0 with updates,    |
+| ``manylinux_x_y`` | pip >= 20.3      | 3.8.10+, 3.9.5+, 3.10.0+   | ALT Linux 10+, RHEL 9+, Debian 11+,       |
+|                   |                  |                            | Fedora 34+, Mageia 8+,                    |
+|                   |                  |                            | Photon OS 3.0 with updates,               |
 |                   |                  |                            | Ubuntu 21.04+                             |
 +-------------------+------------------+----------------------------+-------------------------------------------+
 | ``manylinux2014`` | pip >= 19.3      | 3.7.8+, 3.8.4+, 3.9.0+     | CentOS 7 rh-python38, CentOS 8 python38,  |
@@ -97,6 +102,13 @@ etc., we provide `Docker <https://docker.com/>`_ images where we've
 done the work for you. The images are uploaded to `quay.io`_ and are tagged
 for repeatable builds.
 
+
+manylinux_2_28 (AlmaLinux 8 based)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- x86_64 image: ``quay.io/pypa/manylinux_2_24_x86_64``
+- aarch64 image: ``quay.io/pypa/manylinux_2_24_aarch64``
+- ppc64le image: ``quay.io/pypa/manylinux_2_24_ppc64le``
 
 manylinux_2_24 (Debian 9 based)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -147,7 +159,7 @@ Image content
 
 All images currently contain:
 
-- CPython 3.6, 3.7, 3.8, 3.9, 3.10, and PyPy 3.7, 3.8, 3.9 installed in
+- CPython 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, and PyPy 3.7, 3.8, 3.9 installed in
   ``/opt/python/<python tag>-<abi tag>``. The directories are named
   after the PEP 425 tags for each environment --
   e.g. ``/opt/python/cp37-cp37m`` contains a CPython 3.7 build, and

--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,11 @@ elif [ "${POLICY}" == "manylinux_2_24" ]; then
 	DEVTOOLSET_ROOTPATH=
 	PREPEND_PATH=
 	LD_LIBRARY_PATH_ARG=
+elif [ "${POLICY}" == "manylinux_2_28" ]; then
+	BASEIMAGE="${MULTIARCH_PREFIX}almalinux:8"
+	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-11/root"
+	PREPEND_PATH="${DEVTOOLSET_ROOTPATH}/usr/bin:"
+	LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
 elif [ "${POLICY}" == "musllinux_1_1" ]; then
 	BASEIMAGE="${MULTIARCH_PREFIX}alpine:3.12"
 	DEVTOOLSET_ROOTPATH=

--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -30,7 +30,11 @@ strip_ /manylinux-rootfs
 
 # Install
 cp -rlf /manylinux-rootfs/* /
-ldconfig /
+if [ "${BASE_POLICY}" == "musllinux" ]; then
+	ldconfig /
+elif [ "${BASE_POLICY}" == "manylinux" ]; then
+	ldconfig
+fi
 
 # Clean-up for runtime
 rm -rf /manylinux-rootfs/usr/local/share

--- a/docker/build_scripts/install-build-packages.sh
+++ b/docker/build_scripts/install-build-packages.sh
@@ -8,8 +8,12 @@ set -exuo pipefail
 # if a devel package is added to COMPILE_DEPS,
 # make sure the corresponding library is added to RUNTIME_DEPS if applicable
 
-if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
-	PACKAGE_MANAGER=yum
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+	if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+		PACKAGE_MANAGER=dnf
+	else
+		PACKAGE_MANAGER=yum
+	fi
 	COMPILE_DEPS="bzip2-devel ncurses-devel readline-devel tk-devel gdbm-devel libpcap-devel xz-devel openssl openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel uuid-devel libffi-devel kernel-headers"
 	if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ]; then
 		COMPILE_DEPS="${COMPILE_DEPS} db4-devel"
@@ -40,6 +44,10 @@ elif [ "${PACKAGE_MANAGER}" == "apt" ]; then
 	rm -rf /var/lib/apt/lists/*
 elif [ "${PACKAGE_MANAGER}" == "apk" ]; then
 	apk add --no-cache ${COMPILE_DEPS}
+elif [ "${PACKAGE_MANAGER}" == "dnf" ]; then
+ 	dnf -y install --allowerasing ${COMPILE_DEPS}
+ 	dnf clean all
+ 	rm -rf /var/cache/yum
 else
 	echo "Not implemented"
 	exit 1

--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -13,6 +13,9 @@ source $MY_DIR/build_utils.sh
 if [ "$BASE_POLICY" == "musllinux" ]; then
 	echo "Skip libxcrypt installation on musllinux"
 	exit 0
+elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+	echo "Skip libxcrypt installation on manylinux_2_28"
+	exit 0
 fi
 
 # We need perl 5.14+

--- a/docker/build_scripts/update-system-packages.sh
+++ b/docker/build_scripts/update-system-packages.sh
@@ -33,6 +33,10 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 		find /etc/ssl/certs -name 'DST_Root_CA_X3.pem' -delete
 		update-ca-certificates
 	fi
+elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+	dnf -y upgrade
+	dnf clean all
+	rm -rf /var/cache/yum
 elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
 	apk upgrade --no-cache
 else
@@ -53,7 +57,7 @@ if [ "${BASE_POLICY}" == "manylinux" ]; then
 		if localedef --list-archive | grep -sq -v -i ^en_US.utf8; then
 			localedef --list-archive | grep -v -i ^en_US.utf8 | xargs localedef --delete-from-archive
 		fi
-		if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ]; then
+		if [ "${AUDITWHEEL_POLICY}" == "manylinux2010" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
 			mv -f ${LOCALE_ARCHIVE} ${LOCALE_ARCHIVE}.tmpl
 			build-locale-archive --install-langs="en_US.utf8"
 		elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
@@ -99,5 +103,10 @@ fi
 if [ -f /usr/local/lib/libcrypt.so.1 ]; then
 	# Remove libcrypt to only use installed libxcrypt instead
 	find /lib* /usr/lib* \( -name 'libcrypt.a' -o -name 'libcrypt.so' -o -name 'libcrypt.so.*' -o -name 'libcrypt-2.*.so' \) -delete
+fi
+
+if [ "${BASE_POLICY}" == "musllinux" ]; then
+	ldconfig /
+elif [ "${BASE_POLICY}" == "manylinux" ]; then
 	ldconfig
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -14,6 +14,8 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	apt-get update -qq
 elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
 	PACKAGE_MANAGER=apk
+elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+	PACKAGE_MANAGER=dnf
 else
 	echo "Unsupported policy: '${AUDITWHEEL_POLICY}'"
 	exit 1
@@ -65,6 +67,8 @@ elif [ "${PACKAGE_MANAGER}" == "apt" ]; then
 	apt-get install -qq -y --no-install-recommends openssh-client
 elif [ "${PACKAGE_MANAGER}" == "apk" ]; then
 	apk add --no-cache openssh-client
+elif [ "${PACKAGE_MANAGER}" == "dnf" ]; then
+	dnf -y install --allowerasing openssh-clients
 else
 	echo "Unsupported package manager: '${PACKAGE_MANAGER}'"
 	exit 1


### PR DESCRIPTION
fix #1282

Add manylinux_2_28 images based on AlmaLinux 8.
The following architectures are supported:
- `x86_64`
- `aarch64`
- `ppc64le`

`s390x` might be added later on depending on availability of a base image.
`i686` won't be added.
