### PR TITLE
chore: move to ubuntu 22.04 runners on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 os: linux
-dist: focal
+dist: jammy
 services:
   - docker
 


### PR DESCRIPTION
Check where the deployment's at for jammy on Travis CI.

EDIT: Seems it's not there yet for alt-arch