### PR TITLE
Add Tcl/Tk 8.6 to manylinux2014

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,6 +95,13 @@ RUN export OPENSSL_ROOT=openssl-1.1.1q && \
     export OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source && \
     manylinux-entrypoint /build_scripts/build-openssl.sh
 
+COPY build_scripts/build-tcltk.sh /build_scripts/
+RUN export TCL_ROOT=tcl8.6.12 && export TK_ROOT=tk8.6.12 \
+    export TCL_HASH=26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6 && \
+    export TK_HASH=12395c1f3fcb6bed2938689f797ea3cdf41ed5cb6c4766eec8ac949560310630 && \
+    export TCLTK_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
+    manylinux-entrypoint /build_scripts/build-tcltk.sh
+
 COPY build_scripts/build-cpython.sh /build_scripts/
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,6 @@ RUN export TCL_ROOT=tcl8.6.12 && \
     export TCL_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
     export TK_ROOT=tk8.6.12 && \
     export TK_HASH=12395c1f3fcb6bed2938689f797ea3cdf41ed5cb6c4766eec8ac949560310630 && \
-    export TK_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
     manylinux-entrypoint /build_scripts/build-tcltk.sh
 
 COPY build_scripts/build-cpython.sh /build_scripts/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,10 +96,12 @@ RUN export OPENSSL_ROOT=openssl-1.1.1q && \
     manylinux-entrypoint /build_scripts/build-openssl.sh
 
 COPY build_scripts/build-tcltk.sh /build_scripts/
-RUN export TCL_ROOT=tcl8.6.12 && export TK_ROOT=tk8.6.12 \
+RUN export TCL_ROOT=tcl8.6.12 && \
     export TCL_HASH=26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6 && \
+    export TCL_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
+    export TK_ROOT=tk8.6.12 && \
     export TK_HASH=12395c1f3fcb6bed2938689f797ea3cdf41ed5cb6c4766eec8ac949560310630 && \
-    export TCLTK_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
+    export TK_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
     manylinux-entrypoint /build_scripts/build-tcltk.sh
 
 COPY build_scripts/build-cpython.sh /build_scripts/

--- a/docker/build_scripts/build-tcltk.sh
+++ b/docker/build_scripts/build-tcltk.sh
@@ -17,7 +17,6 @@ check_var ${TCL_HASH}
 check_var ${TCL_DOWNLOAD_URL}
 check_var ${TK_ROOT}
 check_var ${TK_HASH}
-check_var ${TK_DOWNLOAD_URL}
 
 if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] ; then
 	yum erase -y tcl tk
@@ -27,7 +26,7 @@ fi
 
 fetch_source ${TCL_ROOT}-src.tar.gz ${TCL_DOWNLOAD_URL}
 check_sha256sum ${TCL_ROOT}-src.tar.gz ${TCL_HASH}
-fetch_source ${TK_ROOT}-src.tar.gz ${TK_DOWNLOAD_URL}
+fetch_source ${TK_ROOT}-src.tar.gz ${TCL_DOWNLOAD_URL}
 check_sha256sum ${TK_ROOT}-src.tar.gz ${TK_HASH}
 
 tar xfz ${TCL_ROOT}-src.tar.gz

--- a/docker/build_scripts/build-tcltk.sh
+++ b/docker/build_scripts/build-tcltk.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Top-level build script called from Dockerfile
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+source $MY_DIR/build_utils.sh
+
+# Install a more recent Tcl/Tk 8.6
+# https://www.tcl.tk/software/tcltk/download.html
+check_var ${TCL_ROOT}
+check_var ${TK_ROOT}
+check_var ${TCL_HASH}
+check_var ${TK_HASH}
+check_var ${TCLTK_DOWNLOAD_URL}
+
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] ; then
+	yum erase -y tcl tk
+else
+    exit 0
+fi
+
+fetch_source ${TCL_ROOT}-src.tar.gz ${TCLTK_DOWNLOAD_URL}
+check_sha256sum ${TCL_ROOT}-src.tar.gz ${TCL_HASH}
+fetch_source ${TK_ROOT}-src.tar.gz ${TCLTK_DOWNLOAD_URL}
+check_sha256sum ${TK_ROOT}-src.tar.gz ${TK_HASH}
+
+tar xfz ${TCL_ROOT}-src.tar.gz
+pushd ${TCL_ROOT}/unix
+DESTDIR=/manylinux-rootfs do_standard_install
+popd
+
+tar xfz ${TK_ROOT}-src.tar.gz
+pushd ${TK_ROOT}/unix
+DESTDIR=/manylinux-rootfs do_standard_install
+popd
+
+# Remove only after building is complete
+rm -rf ${TCL_ROOT} ${TCL_ROOT}-src.tar.gz
+rm -rf ${TK_ROOT} ${TK_ROOT}-src.tar.gz
+
+# Static library is unused, remove it
+rm /manylinux-rootfs/usr/local/lib/libtclstub8.6.a
+rm /manylinux-rootfs/usr/local/lib/libtkstub8.6.a
+
+# Strip what we can
+strip_ /manylinux-rootfs
+
+# Install
+cp -rlf /manylinux-rootfs/* /
+if [ "${BASE_POLICY}" == "musllinux" ]; then
+	ldconfig /
+elif [ "${BASE_POLICY}" == "manylinux" ]; then
+	ldconfig
+fi
+
+# Clean-up for runtime
+rm -rf /manylinux-rootfs/usr/local/share

--- a/docker/build_scripts/build-tcltk.sh
+++ b/docker/build_scripts/build-tcltk.sh
@@ -13,10 +13,11 @@ source $MY_DIR/build_utils.sh
 # Install a more recent Tcl/Tk 8.6
 # https://www.tcl.tk/software/tcltk/download.html
 check_var ${TCL_ROOT}
-check_var ${TK_ROOT}
 check_var ${TCL_HASH}
+check_var ${TCL_DOWNLOAD_URL}
+check_var ${TK_ROOT}
 check_var ${TK_HASH}
-check_var ${TCLTK_DOWNLOAD_URL}
+check_var ${TK_DOWNLOAD_URL}
 
 if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] ; then
 	yum erase -y tcl tk
@@ -24,9 +25,9 @@ else
     exit 0
 fi
 
-fetch_source ${TCL_ROOT}-src.tar.gz ${TCLTK_DOWNLOAD_URL}
+fetch_source ${TCL_ROOT}-src.tar.gz ${TCL_DOWNLOAD_URL}
 check_sha256sum ${TCL_ROOT}-src.tar.gz ${TCL_HASH}
-fetch_source ${TK_ROOT}-src.tar.gz ${TCLTK_DOWNLOAD_URL}
+fetch_source ${TK_ROOT}-src.tar.gz ${TK_DOWNLOAD_URL}
 check_sha256sum ${TK_ROOT}-src.tar.gz ${TK_HASH}
 
 tar xfz ${TCL_ROOT}-src.tar.gz

--- a/docker/build_scripts/install-build-packages.sh
+++ b/docker/build_scripts/install-build-packages.sh
@@ -14,7 +14,10 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == 
 	else
 		PACKAGE_MANAGER=dnf
 	fi
-	COMPILE_DEPS="bzip2-devel ncurses-devel readline-devel tk-devel gdbm-devel libpcap-devel xz-devel openssl openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel uuid-devel libffi-devel kernel-headers libdb-devel"
+	COMPILE_DEPS="bzip2-devel ncurses-devel readline-devel gdbm-devel libpcap-devel xz-devel openssl openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel uuid-devel libffi-devel kernel-headers libdb-devel"
+    if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+        COMPILE_DEPS="${COMPILE_DEPS} tk-devel"
+    fi
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	PACKAGE_MANAGER=apt
 	COMPILE_DEPS="libbz2-dev libncurses5-dev libreadline-dev tk-dev libgdbm-dev libdb-dev libpcap-dev liblzma-dev openssl libssl-dev libkeyutils-dev libkrb5-dev comerr-dev libidn2-0-dev libcurl4-openssl-dev uuid-dev libffi-dev linux-kernel-headers"

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -45,7 +45,10 @@ fi
 
 # RUNTIME_DEPS: Runtime dependencies. c.f. install-build-packages.sh
 if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
-	RUNTIME_DEPS="zlib bzip2 expat ncurses readline tk gdbm libpcap xz openssl keyutils-libs libkadm5 libcom_err libidn libcurl uuid libffi libdb"
+	RUNTIME_DEPS="zlib bzip2 expat ncurses readline gdbm libpcap xz openssl keyutils-libs libkadm5 libcom_err libidn libcurl uuid libffi libdb"
+    if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
+        RUNTIME_DEPS="${RUNTIME_DEPS} tk"
+    fi
 elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_24" ]; then
 	RUNTIME_DEPS="zlib1g libbz2-1.0 libexpat1 libncurses5 libreadline7 tk libgdbm3 libdb5.3 libpcap0.8 liblzma5 libssl1.1 libkeyutils1 libkrb5-3 libcomerr2 libidn2-0 libcurl3 uuid libffi6"
 elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then


### PR DESCRIPTION
I'm using manylinux2014 to generate wheels for cx_Freeze. As Tcl/Tk 8.5 is still used, it ended up creating an issue (https://github.com/marcelotduarte/cx_Freeze/issues/1577). So I upgrade to Tcl/Tk 8.6 in the same way as sqlite3.