### PR TITLE
Remove removal of test module (closes #1382)

### DIFF
--- a/docker/build_scripts/install-pypy.sh
+++ b/docker/build_scripts/install-pypy.sh
@@ -68,8 +68,5 @@ fi
 # remove debug symbols
 rm ${PREFIX}/bin/*.debug
 
-# We do not need the Python test suites
-find ${PREFIX} -depth \( -type d -a -name test -o -name tests \) | xargs rm -rf
-
 # We do not need precompiled .pyc and .pyo files.
 clean_pyc ${PREFIX}


### PR DESCRIPTION
This PR restores the `test` module to the PyPy runtimes available in the Docker images, doing for PyPy what #1166 did for CPython