### PR TITLE
Revert "Bump openssl 1.1.1q → 1.1.1r"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,8 +90,8 @@ RUN export SQLITE_AUTOCONF_ROOT=sqlite-autoconf-3390400 && \
     manylinux-entrypoint /build_scripts/build-sqlite3.sh
 
 COPY build_scripts/build-openssl.sh /build_scripts/
-RUN export OPENSSL_ROOT=openssl-1.1.1r && \
-    export OPENSSL_HASH=e389352ae3d5ae4d38597bf8a54f1dcb6fb3c8b50f4fe58a94bb1bf7f85d82a0 && \
+RUN export OPENSSL_ROOT=openssl-1.1.1q && \
+    export OPENSSL_HASH=d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca && \
     export OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source && \
     manylinux-entrypoint /build_scripts/build-openssl.sh
 


### PR DESCRIPTION
This reverts commit c1eb322b4e218f0709d30fc7e76b11be7b36bba8.

Per https://www.openssl.org:
> 12-Oct-2022 OpenSSL 3.0.6 and 1.1.1r are withdrawn. New releases will be created in due course.
