### PR TITLE
Add GNU tar to musllinux images

### DIFF
--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -102,7 +102,7 @@ elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
 	fi
 elif [ "${AUDITWHEEL_POLICY}" == "musllinux_1_1" ]; then
 	TOOLCHAIN_DEPS="binutils gcc g++ gfortran"
-	BASETOOLS="${BASETOOLS} curl util-linux"
+	BASETOOLS="${BASETOOLS} curl util-linux tar"
 	PACKAGE_MANAGER=apk
 	apk add --no-cache ca-certificates gnupg
 else

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -55,6 +55,7 @@ sqlite3 --version
 pipx run nox --version
 pipx install --pip-args='--no-python-version-warning --no-input' nox
 nox --version
+tar --version | grep "GNU tar"
 
 # check libcrypt.so.1 can be loaded by some system packages,
 # as LD_LIBRARY_PATH might not be enough.


### PR DESCRIPTION
c.f. https://github.com/pypa/cibuildwheel/pull/1434

GNU tar being used in manylinux images, this also help to get a more consistent environment between the 2 kind of images.
