### PR TITLE
Multiple small improvements

### DIFF
--- a/docker/build_scripts/python-tag-abi-tag.py
+++ b/docker/build_scripts/python-tag-abi-tag.py
@@ -2,7 +2,7 @@
 # See PEP 425 for exactly what these are, but an example would be:
 #   cp27-cp27mu
 
-from wheel.vendored.packaging.tags import sys_tags
+from packaging.tags import sys_tags
 
 
 # first tag is always the more specific tag

--- a/docker/build_scripts/requirements3.10.txt
+++ b/docker/build_scripts/requirements3.10.txt
@@ -11,7 +11,9 @@ build==0.10.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/docker/build_scripts/requirements3.11.txt
+++ b/docker/build_scripts/requirements3.11.txt
@@ -11,7 +11,9 @@ build==0.10.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/docker/build_scripts/requirements3.12.txt
+++ b/docker/build_scripts/requirements3.12.txt
@@ -11,7 +11,9 @@ build==0.10.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/docker/build_scripts/requirements3.6.txt
+++ b/docker/build_scripts/requirements3.6.txt
@@ -17,7 +17,9 @@ importlib-metadata==4.8.3 \
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pep517==0.13.0 \
     --hash=sha256:4ba4446d80aed5b5eac6509ade100bff3e7943a8489de249654a5ae9b33ee35b \
     --hash=sha256:ae69927c5c172be1add9203726d4b84cf3ebad1edcd5f71fcdc746e66e829f59

--- a/docker/build_scripts/requirements3.7.txt
+++ b/docker/build_scripts/requirements3.7.txt
@@ -15,7 +15,9 @@ importlib-metadata==6.7.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/docker/build_scripts/requirements3.8.txt
+++ b/docker/build_scripts/requirements3.8.txt
@@ -11,7 +11,9 @@ build==0.10.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/docker/build_scripts/requirements3.9.txt
+++ b/docker/build_scripts/requirements3.9.txt
@@ -11,7 +11,9 @@ build==0.10.0 \
 packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
-    # via build
+    # via
+    #   -r requirements.in
+    #   build
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ pip
 setuptools
 wheel
 build
+packaging

--- a/tests/forty-two/forty-two.c
+++ b/tests/forty-two/forty-two.c
@@ -1,0 +1,20 @@
+#include <Python.h>
+
+static PyObject * answer(PyObject *self, PyObject *args)
+{
+    return PyLong_FromLong(42);
+}
+
+/* Module initialization */
+static PyMethodDef module_methods[] = {
+    {"answer", (PyCFunction)answer, METH_NOARGS, "The answer."},
+    {NULL}  /* Sentinel */
+};
+
+PyMODINIT_FUNC PyInit_forty_two(void)
+{
+    static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT, "forty_two", "The answer module", -1, module_methods,
+    };
+    return PyModule_Create(&moduledef);
+}

--- a/tests/forty-two/pyproject.toml
+++ b/tests/forty-two/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/forty-two/setup.py
+++ b/tests/forty-two/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, Extension
+
+setup(
+    name="forty_two",
+    version="0.1.0",
+    python_requires=">=3.6",
+    ext_modules=[Extension("forty_two", sources=["forty-two.c"])],
+)


### PR DESCRIPTION
- tests: build a minimal project with each interpreter
To check we're able to build a minimal project with each interpreter.
- chore: use packaging directly in python-tag-abi-tag.py
Not to depend on an implementation detail of wheel.