### PR TITLE
Add GraalPy

### DIFF
--- a/docker/build_scripts/manylinux-interpreters.py
+++ b/docker/build_scripts/manylinux-interpreters.py
@@ -21,6 +21,8 @@ def sort_key(tag):
     python_tag, _ = tag.split("-")
     if python_tag.startswith(("cp", "pp")):
         return python_tag[:2], int(python_tag[2]), int(python_tag[3:])
+    if python_tag.startswith("graalpy"):
+        return python_tag[:7], int(python_tag[7]), int(python_tag[8:])
     raise LookupError(tag)
 
 
@@ -81,6 +83,12 @@ def get_info_from_tag(tag):
         return {
             "pv": f"{python_tag[2]}.{python_tag[3:]}",
             "i": "pypy",
+            "iv": PYTHON_TAGS[tag][ARCH]["version"]
+        }
+    if python_tag.startswith("graalpy"):
+        return {
+            "pv": f"{python_tag[7]}.{python_tag[8:]}",
+            "i": "graalpy",
             "iv": PYTHON_TAGS[tag][ARCH]["version"]
         }
     raise LookupError(tag)

--- a/docker/build_scripts/python_versions.json
+++ b/docker/build_scripts/python_versions.json
@@ -1,4 +1,16 @@
 {
+  "graalpy310-graalpy240_310_native": {
+    "x86_64": {
+      "version": "24.0.1",
+      "download_url": "https://github.com/oracle/graalpython/releases/download/graal-24.0.1/graalpy-24.0.1-linux-amd64.tar.gz",
+      "sha256": "c804a2a130866d50841c24e98b7c4d9257528fa97a6890344c6aa0710fb861ef"
+    },
+    "aarch64": {
+      "version": "24.0.1",
+      "download_url": "https://github.com/oracle/graalpython/releases/download/graal-24.0.1/graalpy-24.0.1-linux-aarch64.tar.gz",
+      "sha256": "5c6fd064213d3be633c42183abd4f0d971145c43f99efc9831578a6ce99e2437"
+    }
+  },
   "pp37-pypy37_pp73": {
     "x86_64": {
       "version": "7.3.9",

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -21,7 +21,10 @@ if [ "${AUDITWHEEL_POLICY:0:10}" == "musllinux_" ]; then
 	EXPECTED_PYTHON_COUNT=9
 	EXPECTED_PYTHON_COUNT_ALL=9
 else
-	if [ "${AUDITWHEEL_ARCH}" == "x86_64" ] || [ "${AUDITWHEEL_ARCH}" == "i686" ] || [ "${AUDITWHEEL_ARCH}" == "aarch64" ]; then
+	if [ "${AUDITWHEEL_ARCH}" == "x86_64" ] || [ "${AUDITWHEEL_ARCH}" == "aarch64" ]; then
+		EXPECTED_PYTHON_COUNT=13
+		EXPECTED_PYTHON_COUNT_ALL=14
+	elif [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
 		EXPECTED_PYTHON_COUNT=13
 		EXPECTED_PYTHON_COUNT_ALL=13
 	else

--- a/tools/update_interpreters_download.py
+++ b/tools/update_interpreters_download.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 from hashlib import sha256
 from pathlib import Path
@@ -19,6 +20,15 @@ from packaging.version import Version
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve(strict=True)
 PYTHON_VERSIONS = PROJECT_ROOT / "docker" / "build_scripts" / "python_versions.json"
+
+
+def get_sha256(url: str) -> str:
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    sha256sum = sha256()
+    for chunk in response.iter_content(chunk_size=1024 * 4):
+        sha256sum.update(chunk)
+    return sha256sum.hexdigest()
 
 
 def update_pypy_version(releases, py_spec, pp_spec, tag, arch, version_dict, updates):
@@ -42,14 +52,9 @@ def update_pypy_version(releases, py_spec, pp_spec, tag, arch, version_dict, upd
             continue
         message = f"updating {tag} {arch} to {r['pypy_version']}"
         print(message)
-        response = requests.get(file["download_url"], stream=True)
-        response.raise_for_status()
-        sha256sum = sha256()
-        for chunk in response.iter_content(chunk_size=1024 * 4):
-            sha256sum.update(chunk)
         version_dict["version"] = str(r["pypy_version"])
         version_dict["download_url"] = file["download_url"]
-        version_dict["sha256"] = sha256sum.hexdigest()
+        version_dict["sha256"] = get_sha256(file["download_url"])
         updates.append(message)
         break
 
@@ -88,6 +93,68 @@ def update_pypy_versions(versions, updates):
             )
 
 
+def update_graalpy_version(releases, graalpy_spec, tag, arch, version_dict, updates):
+    graalpy_arch = {"x86_64": "amd64"}.get(arch, arch)
+    current_version = None
+    if "version" in version_dict:
+        current_version = Version(version_dict["version"])
+    for r in releases:
+        version = Version(r["tag_name"].split('-')[1])
+        if current_version is not None and current_version >= version:
+            continue
+        if not graalpy_spec.contains(version):
+            continue
+        asset_found = False
+        for asset in r["assets"]:
+            if asset["name"] == f"graalpy-{version}-linux-{graalpy_arch}.tar.gz":
+                asset_found = True
+                break
+        if not asset_found:
+            continue
+        message = f"updating {tag} {arch} to {version}"
+        print(message)
+        version_dict["version"] = str(version)
+        version_dict["download_url"] = asset["browser_download_url"]
+        version_dict["sha256"] = get_sha256(asset["browser_download_url"])
+        updates.append(message)
+        break
+
+
+def get_next_page_link(response):
+    link = response.headers.get("link")
+    if link:
+        for part in re.split(r"\s*,\s*", link):
+            split = re.split(r"\s*;\s*", part)
+            url = split[0][1:-1]
+            for param in split[1:]:
+                if re.match(r'rel="?next"?', param):
+                    return url
+
+
+def update_graalpy_versions(versions, updates):
+    releases = []
+    url = "https://api.github.com/repos/oracle/graalpython/releases"
+    while url:
+        response = requests.get(url)
+        response.raise_for_status()
+        releases += response.json()
+        url = get_next_page_link(response)
+    for tag in versions:
+        if not tag.startswith("graalpy"):
+            continue
+        _, abi_tag = tag.split("-")
+        graalpy_ver, _, _ = abi_tag.split("_")
+        assert graalpy_ver.startswith("graalpy")
+        graalpy_ver = graalpy_ver[len("graalpy"):]
+        graalpy_major = int(graalpy_ver[:2])
+        graalpy_minor = int(graalpy_ver[2:])
+        graalpy_spec = Specifier(f"=={graalpy_major}.{graalpy_minor}.*")
+        for arch in versions[tag]:
+            update_graalpy_version(
+                releases, graalpy_spec, tag, arch, versions[tag][arch], updates
+            )
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="dry run")
@@ -95,6 +162,7 @@ def main():
     versions = json.loads(PYTHON_VERSIONS.read_text())
     updates = []
     update_pypy_versions(versions, updates)
+    update_graalpy_versions(versions, updates)
     if not args.dry_run:
         PYTHON_VERSIONS.write_text(json.dumps(versions, indent=2))
         if updates:


### PR DESCRIPTION
In order to install GraalPy in the image, one must call `manylinux-interpreters ensure graalpy310-graalpy230_310_native`.

closes #1509