### PR TITLE
fix: entrypoint on i686

### DIFF
--- a/docker/manylinux-entrypoint
+++ b/docker/manylinux-entrypoint
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
+if [ "${AUDITWHEEL_ARCH}" == "i686" ] && [ "$(uname -m)" == "x86_64" ]; then
 	linux32 "$@"
 else
 	exec "$@"


### PR DESCRIPTION
When running with docker on macOS aarch64,
i686 images will use qemu which already defaults to an i686 emulation. This results in the `linux32` command to fail.
Use `linux32` only if `uname -m` reports x86_64.