### PR TITLE
chore: move openssl update to 3.0.x branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,8 +102,8 @@ COPY build_scripts/build-cpython.sh /build_scripts/
 
 FROM build_cpython_system_ssl AS build_cpython
 COPY build_scripts/build-openssl.sh /build_scripts/
-RUN export OPENSSL_ROOT=openssl-1.1.1w && \
-    export OPENSSL_HASH=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8 && \
+RUN export OPENSSL_ROOT=openssl-3.0.11 && \
+    export OPENSSL_HASH=b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55 && \
     export OPENSSL_DOWNLOAD_URL=https://www.openssl.org/source && \
     manylinux-entrypoint /build_scripts/build-openssl.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,7 +138,7 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.11.5
 
 FROM build_cpython AS build_cpython312
 COPY build_scripts/cpython-pubkey-312-313.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.12.0rc2
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.12.0rc3
 
 FROM build_cpython AS all_cpython
 COPY build_scripts/finalize-python.sh /build_scripts/

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -39,7 +39,7 @@ fetch_source ${OPENSSL_ROOT}.tar.gz ${OPENSSL_DOWNLOAD_URL}
 check_sha256sum ${OPENSSL_ROOT}.tar.gz ${OPENSSL_HASH}
 tar -xzf ${OPENSSL_ROOT}.tar.gz
 pushd ${OPENSSL_ROOT}
-./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS} -fPIC" CXXFLAGS="${MANYLINUX_CXXFLAGS} -fPIC" LDFLAGS="${MANYLINUX_LDFLAGS} -fPIC" > /dev/null
+./config no-shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS} -fPIC" CXXFLAGS="${MANYLINUX_CXXFLAGS} -fPIC" LDFLAGS="${MANYLINUX_LDFLAGS} -fPIC" > /dev/null
 make > /dev/null
 make install_sw > /dev/null
 popd

--- a/docker/build_scripts/install-build-packages.sh
+++ b/docker/build_scripts/install-build-packages.sh
@@ -14,7 +14,7 @@ source $MY_DIR/build_utils.sh
 # make sure the corresponding library is added to RUNTIME_DEPS if applicable
 
 if [ "${BASE_POLICY}" == "manylinux" ]; then
-	COMPILE_DEPS="bzip2-devel ncurses-devel readline-devel gdbm-devel libpcap-devel xz-devel openssl openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel uuid-devel libffi-devel kernel-headers libdb-devel"
+	COMPILE_DEPS="bzip2-devel ncurses-devel readline-devel gdbm-devel libpcap-devel xz-devel openssl openssl-devel keyutils-libs-devel krb5-devel libcom_err-devel libidn-devel curl-devel uuid-devel libffi-devel kernel-headers libdb-devel perl-IPC-Cmd"
 	if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
 		PACKAGE_MANAGER=yum
 		COMPILE_DEPS="${COMPILE_DEPS} libXft-devel"

--- a/docker/build_scripts/requirements3.8.txt
+++ b/docker/build_scripts/requirements3.8.txt
@@ -32,9 +32,9 @@ wheel==0.41.2 \
     --hash=sha256:0c5ac5ff2afb79ac23ab82bab027a0be7b5dbcf2e54dc50efe4bf507de1f7985 \
     --hash=sha256:75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8
     # via -r requirements.in
-zipp==3.16.2 \
-    --hash=sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0 \
-    --hash=sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147
+zipp==3.17.0 \
+    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
+    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/docker/build_scripts/requirements3.9.txt
+++ b/docker/build_scripts/requirements3.9.txt
@@ -32,9 +32,9 @@ wheel==0.41.2 \
     --hash=sha256:0c5ac5ff2afb79ac23ab82bab027a0be7b5dbcf2e54dc50efe4bf507de1f7985 \
     --hash=sha256:75909db2664838d015e3d9139004ee16711748a52c8f336b52882266540215d8
     # via -r requirements.in
-zipp==3.16.2 \
-    --hash=sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0 \
-    --hash=sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147
+zipp==3.17.0 \
+    --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \
+    --hash=sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tools/update_native_dependencies.py
+++ b/tools/update_native_dependencies.py
@@ -58,7 +58,7 @@ def _update_with_root(tool, dry_run):
         "openssl": "openssl/openssl",
     }
     major = {
-        "openssl": "1.1",
+        "openssl": "3.0",
     }
     lines = DOCKERFILE.read_text().splitlines()
     re_ = re.compile(f"^RUN export {tool.upper()}_ROOT={tool}-(?P<version>\\S+) && \\\\$")
@@ -70,10 +70,6 @@ def _update_with_root(tool, dry_run):
         latest_version = latest(repo[tool], major=major.get(tool, None))
         if latest_version > current_version:
             root = f"{tool}-{latest_version}"
-            if root == "openssl-1.1.1r":
-                # withdrawn version
-                print(f"Skipping {root}")
-                break
             url = re.match(f"^    export {tool.upper()}_DOWNLOAD_URL=(?P<url>\\S+) && \\\\$", lines[i + 2])["url"]
             url = url.replace(f"${{{tool.upper()}_ROOT}}", root)
             sha256 = _sha256(f"{url}/{root}.tar.gz")


### PR DESCRIPTION
move openssl update to 3.0.x branch & run `nox -s update_native_dependencies update_python_dependencies`

Closes #1498
Closes #1536