### PR TITLE
Build shared libpython.so

### DIFF
--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -47,8 +47,8 @@ fi
 # do not change the default for user built extension (yet?)
 ./configure \
 	CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS} ${CFLAGS_EXTRA}" \
-	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS}" \
-	--prefix=${PREFIX} --disable-shared --with-ensurepip=no > /dev/null
+	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS} -Wl,--rpath=${PREFIX}/lib" \
+	--prefix=${PREFIX} --enable-shared --with-ensurepip=no > /dev/null
 make > /dev/null
 make install > /dev/null
 popd

--- a/docker/build_scripts/finalize-python.sh
+++ b/docker/build_scripts/finalize-python.sh
@@ -3,11 +3,4 @@
 # Stop at any error, show all commands
 set -exuo pipefail
 
-# most people don't need libpython*.a, and they're many megabytes.
-# compress them all together for best efficiency
-pushd /opt/_internal
-XZ_OPT=-9e tar -cJf static-libs-for-embedding-only.tar.xz cpython-*/lib/libpython*.a
-popd
-find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
-
 hardlink -cv /opt/_internal


### PR DESCRIPTION
Our project (http://git.ligo.org/lscsoft/lalsuite, https://pypi.org/project/lalsuite/) distributes several C command line programs that embed Python interpreters by linking against libpython, plus some Python C extensions modules (which of course do not link against libpython).

For those rare cases like ours where Python embedding is required, using a shared library libpython permits auditwheel to deduplicate libpython and store only one copy in the wheel.