### PR TITLE
Add podman to the list of valid build frontends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,7 +245,9 @@ current (root) directory:
 
     $ PLATFORM=$(uname -m) POLICY=manylinux2014 COMMIT_SHA=latest ./build.sh
 
-Please note that the Docker build is using `buildx <https://github.com/docker/buildx>`_.
+Please note that the default Docker build is using `buildx <https://github.com/docker/buildx>`_.
+Other frontends can be selected by defining `MANYLINUX_BUILD_FRONTEND`. See `build.sh` for
+details.
 
 Updating the requirements
 -------------------------

--- a/build.sh
+++ b/build.sh
@@ -83,6 +83,8 @@ fi
 
 if [ "${MANYLINUX_BUILD_FRONTEND}" == "docker" ]; then
 	docker build ${BUILD_ARGS_COMMON}
+elif [ "${MANYLINUX_BUILD_FRONTEND}" == "podman" ]; then
+	podman build ${BUILD_ARGS_COMMON}
 elif [ "${MANYLINUX_BUILD_FRONTEND}" == "docker-buildx" ]; then
 	docker buildx build \
 		--load \
@@ -106,7 +108,7 @@ fi
 
 docker run --rm -v $(pwd)/tests:/tests:ro quay.io/pypa/${POLICY}_${PLATFORM}:${COMMIT_SHA} /tests/run_tests.sh
 
-if [ "${MANYLINUX_BUILD_FRONTEND}" != "docker" ]; then
+if ! [[ "${MANYLINUX_BUILD_FRONTEND}" =~ (docker)|(podman) ]]; then
 	if [ -d $(pwd)/.buildx-cache-${POLICY}_${PLATFORM} ]; then
 		rm -rf $(pwd)/.buildx-cache-${POLICY}_${PLATFORM}
 	fi


### PR DESCRIPTION
Add podman to the list of valid frontends and document `MANYLINUX_BUILD_FRONTEND` in the readme.