### PR TITLE
 Bump CPython 3.13.0b4 → 3.13.0rc1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,11 +139,11 @@ RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.12.4
 
 FROM build_cpython AS build_cpython313
 COPY build_scripts/cpython-pubkey-312-313.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.13.0b4
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.13.0rc1
 
 FROM build_cpython AS build_cpython313_nogil
 COPY build_scripts/cpython-pubkey-312-313.txt /build_scripts/cpython-pubkeys.txt
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.13.0b4 nogil
+RUN manylinux-entrypoint /build_scripts/build-cpython.sh 3.13.0rc1 nogil
 
 
 FROM runtime_base


### PR DESCRIPTION
 Bump CPython 3.13.0b4 → 3.13.0rc1.

This is a small cherry pick from https://github.com/pypa/manylinux/pull/1652, to get 3.13.0rc1 as fast as feasible into manylinux builds, since it's blocking https://github.com/pypa/cibuildwheel/pull/1949, which is blocking Python 3.13 wheels from getting uploaded to PyPI.