### PR TITLE
Only install libxcrypt on manylinux2014

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,9 +64,6 @@ COPY build_scripts/install-libxcrypt.sh /build_scripts/
 RUN export LIBXCRYPT_VERSION=4.4.36 && \
     export LIBXCRYPT_HASH=b979838d5f1f238869d467484793b72b8bca64c4eae696fdbba0a9e0b6c28453 && \
     export LIBXCRYPT_DOWNLOAD_URL=https://github.com/besser82/libxcrypt/archive && \
-    export PERL_ROOT=perl-5.34.0 && \
-    export PERL_HASH=551efc818b968b05216024fb0b727ef2ad4c100f8cb6b43fab615fa78ae5be9a && \
-    export PERL_DOWNLOAD_URL=https://www.cpan.org/src/5.0 && \
     manylinux-entrypoint /build_scripts/install-libxcrypt.sh
 
 FROM runtime_base AS build_base

--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -10,31 +10,9 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 # Get build utilities
 source $MY_DIR/build_utils.sh
 
-if [ "$BASE_POLICY" == "musllinux" ]; then
-	echo "Skip libxcrypt installation on musllinux"
+if [ "${AUDITWHEEL_POLICY}" != "manylinux2014" ]; then
+	echo "Skip libxcrypt installation on ${AUDITWHEEL_POLICY}"
 	exit 0
-elif [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ]; then
-	echo "Skip libxcrypt installation on manylinux_2_28"
-	exit 0
-fi
-
-# We need perl 5.14+
-if ! perl -e 'use 5.14.0' &> /dev/null; then
-	check_var ${PERL_ROOT}
-	check_var ${PERL_HASH}
-	check_var ${PERL_DOWNLOAD_URL}
-	fetch_source ${PERL_ROOT}.tar.gz ${PERL_DOWNLOAD_URL}
-	check_sha256sum "${PERL_ROOT}.tar.gz" "${PERL_HASH}"
-
-	tar -xzf ${PERL_ROOT}.tar.gz
-	pushd ${PERL_ROOT}
-	./Configure -des -Dprefix=/tmp/perl-libxcrypt > /dev/null
-	make -j$(nproc) > /dev/null
-	make install > /dev/null
-	popd
-
-	rm -rf ${PERL_ROOT}.tar.gz ${PERL_ROOT}
-	export PATH=/tmp/perl-libxcrypt/bin:${PATH}
 fi
 
 # Install libcrypt.so.1 and libcrypt.so.2
@@ -77,8 +55,3 @@ rm -rf /manylinux-rootfs
 rm -rf /usr/include/crypt.h
 find /lib* /usr/lib* \( -name 'libcrypt.a' -o -name 'libcrypt.so' -o -name 'libcrypt.so.*' -o -name 'libcrypt-2.*.so' \) -delete
 ldconfig
-
-# Remove temp Perl
-if [ -d /tmp/perl-libxcrypt ]; then
-	rm -rf /tmp/perl-libxcrypt
-fi


### PR DESCRIPTION
It's only ever going to be used on manylinux2014 now that manylinux2010 & manylinux_2_24 are out of support.

Only install on manylinux2014 rather than skipping on other policies & remove manylinux2010 perl setup.