### PR TITLE
chore: use manylinux2014_base base image for manylinux2014

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,11 +37,7 @@ fi
 
 # setup BASEIMAGE and its specific properties
 if [ "${POLICY}" == "manylinux2014" ]; then
-	if [ "${PLATFORM}" == "s390x" ]; then
-		BASEIMAGE="s390x/clefos:7"
-	else
-		BASEIMAGE="${MULTIARCH_PREFIX}centos:7"
-	fi
+	BASEIMAGE="quay.io/pypa/manylinux2014_base:2024.11.03-3"
 	DEVTOOLSET_ROOTPATH="/opt/rh/devtoolset-10/root"
 	PREPEND_PATH="${DEVTOOLSET_ROOTPATH}/usr/bin:"
 	if [ "${PLATFORM}" == "i686" ]; then

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -88,8 +88,10 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
 	if [ "${AUDITWHEEL_ARCH}" == "x86_64" ]; then
 		# Software collection (for devtoolset-10)
 		yum -y install centos-release-scl-rh
-		# EPEL support (for yasm)
-		yum -y install https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+		if ! rpm -q epel-release-7-14.noarch; then
+			# EPEL support (for yasm)
+			yum -y install https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
+		fi
 		TOOLCHAIN_DEPS="${TOOLCHAIN_DEPS} yasm"
 	elif [ "${AUDITWHEEL_ARCH}" == "aarch64" ] || [ "${AUDITWHEEL_ARCH}" == "ppc64le" ] || [ "${AUDITWHEEL_ARCH}" == "s390x" ]; then
 		# Software collection (for devtoolset-10)


### PR DESCRIPTION
With CentOS 7 having reach EOL, packages versions are now immutable. Using a base image with manylinux runtime packages allows to reduce image size and improve cache efficiency.