### PR TITLE
Remove deprecated `--no-python-version-warning` option

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -125,7 +125,7 @@ git --version
 cmake --version
 swig -version
 pipx run nox --version
-pipx install --pip-args='--no-python-version-warning --no-input' nox
+pipx install --pip-args='--no-input' nox
 nox --version
 tar --version | grep "GNU tar"
 # we stopped installing sqlite3 after manylinux_2_28 / musllinux_1_2


### PR DESCRIPTION
This option is scheduled to be removed in pip 25.1 (pip uses CalVer and this will be Q2 2025):

> **-​-no-python-version-warning**
Deprecated since pip 25.0
([#13154](https://github.com/pypa/pip/issues/13154)) The flag has long done nothing since Python 2 support was removed in pip 21.0. pip has also never warned about deprecations of any other Python version as the flag’s help suggests.

https://ichard26.github.io/blog/2025/01/whats-new-in-pip-25.0/#upcoming-removals

https://github.com/pypa/pip/issues/13154
