### PR TITLE
feat: manylinux_2_39_aarch64, manylinux_2_39_riscv64 & musllinux_1_2_riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,10 @@ jobs:
           import json
           reduced = [
               ("x86_64", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
-              ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
+              ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "manylinux_2_39", "musllinux_1_2")),
               ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
+              ("riscv64", "ubuntu-24.04", ("manylinux_2_39", "musllinux_1_2")),
               ("s390x", "ubuntu-24.04", ("musllinux_1_2",)),
           ]
           expanded = [{"policy": policy, "platform": platform, "runner": runner} for platform, runner, policies in reduced for policy in policies]
@@ -79,7 +80,7 @@ jobs:
           fetch-depth: 50
 
       - name: Set up QEMU
-        if: matrix.platform == 's390x'
+        if: matrix.platform == 's390x' || matrix.platform == 'riscv64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ The manylinux project supports:
 
 - ``manylinux_2_34`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
+- ``manylinux_2_39`` images for ``aarch64`` and ``riscv64``.
+
 - ``musllinux_1_2`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le``, ``s390x`` and ``armv7l``.
 
 
@@ -93,6 +95,23 @@ etc., we provide `Docker <https://docker.com/>`_ images where we've
 done the work for you. The images are uploaded to `quay.io`_ and are tagged
 for repeatable builds.
 
+manylinux_2_39 (AlmaLinux/RockyLinux 10 based) - ALPHA
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Toolchain: GCC 14
+
+- aarch64 image: ``quay.io/pypa/manylinux_2_39_aarch64``
+- riscv64 image: ``quay.io/pypa/manylinux_2_39_riscv64``
+
+Built wheels are also expected to be compatible with other
+distros using glibc 2.39 or later, including:
+
+- Debian 13+
+- Ubuntu 24.04+
+- Fedora 40+
+- CentOS/RHEL 10+
+
+
 manylinux_2_34 (AlmaLinux 9 based) - ALPHA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -119,7 +138,6 @@ distros using glibc 2.34 or later, including:
 - Ubuntu 21.10+
 - Fedora 35+
 - CentOS/RHEL 9+
-
 
 
 manylinux_2_31 (Ubuntu 20.04 based) - armv7l only - BETA

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,19 @@ elif [ "${POLICY}" == "manylinux_2_35" ]; then
 	DEVTOOLSET_ROOTPATH=
 	PREPEND_PATH=
 	LD_LIBRARY_PATH_ARG=
+elif [ "${POLICY}" == "manylinux_2_39" ]; then
+	BASEIMAGE="quay.io/almalinuxorg/almalinux:10"
+	case "${PLATFORM}" in
+		x86_64) GOARCH="amd64/v2";;
+		riscv64) BASEIMAGE="rockylinux/rockylinux:10";;
+	esac
+	# TODO enable gcc-toolset-15 once available (probably in 10.1)
+	# DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-15/root"
+	# PREPEND_PATH="/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:"
+	# LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
+	DEVTOOLSET_ROOTPATH=
+	PREPEND_PATH=
+	LD_LIBRARY_PATH_ARG=
 elif [ "${POLICY}" == "musllinux_1_2" ]; then
 	BASEIMAGE="alpine:3.22"
 	DEVTOOLSET_ROOTPATH=

--- a/deploy_multiarch.sh
+++ b/deploy_multiarch.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-IMAGES=(manylinux2014 manylinux_2_28 manylinux_2_31 manylinux_2_34 musllinux_1_2)
+IMAGES=(manylinux2014 manylinux_2_28 manylinux_2_31 manylinux_2_34 manylinux_2_39 musllinux_1_2)
 
 podman login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
@@ -32,7 +32,8 @@ for IMAGE in "${IMAGES[@]}"; do
 
 	case ${IMAGE} in
 		manylinux_2_31) ARCHS=("armv7l");;
-		musllinux_1_2) ARCHS=("x86_64" "i686" "aarch64" "armv7l" "ppc64le" "s390x");;
+		manylinux_2_39) ARCHS=("aarch64" "riscv64");;
+		musllinux_1_2) ARCHS=("x86_64" "i686" "aarch64" "armv7l" "ppc64le" "s390x" "riscv64");;
 		*) ARCHS=("x86_64" "i686" "aarch64" "ppc64le" "s390x");;
 	esac
 

--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -86,6 +86,12 @@ for TOOL_PATH in "${MY_DIR}/requirements-tools/"*; do
 	case ${AUDITWHEEL_PLAT}-${TOOL} in
 		musllinux*_ppc64le-uv) continue;;  # uv doesn't provide musl ppc64le wheels due to Rust issues
 		musllinux*_s390x-uv) continue;;  # uv doesn't provide musl s390x wheels due to Rust issues
+		*_riscv64-uv) continue;;  # no uv for riscv64
+		*_riscv64-cmake|*_riscv64-swig) manylinux_pkg_install "${TOOL}";;
+		*_riscv64-patchelf)
+			manylinux_pkg_install cmake
+			pipx install patchelf==0.17.2.2
+			;;
 		*) pipx install --pip-args="--require-hashes -r ${TOOL_PATH} --only-binary" "${TOOL}";;
 	esac
 done

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -121,7 +121,7 @@ elif [ "${OS_ID_LIKE}" == "rhel" ]; then
 	echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
 	dnf -y upgrade
 	EPEL=epel-release
-	if [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
+	if [ "${AUDITWHEEL_ARCH}" == "i686" ] || [ "${AUDITWHEEL_ARCH}" == "riscv64" ]; then
 		EPEL=
 	fi
 	dnf -y install dnf-plugins-core ${EPEL}
@@ -130,7 +130,13 @@ elif [ "${OS_ID_LIKE}" == "rhel" ]; then
 	else
 		dnf config-manager --set-enabled crb
 	fi
-	TOOLCHAIN_DEPS=(gcc-toolset-14-binutils gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-gcc-gfortran gcc-toolset-14-libatomic-devel)
+	if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_34" ]; then
+		TOOLCHAIN_DEPS=(gcc-toolset-14-binutils gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-gcc-gfortran gcc-toolset-14-libatomic-devel)
+	else
+		# TODO enable gcc-toolset-15 once available (probably in 10.1)
+		# TOOLCHAIN_DEPS=(gcc-toolset-15-binutils gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-gcc-gfortran gcc-toolset-15-libatomic-devel)
+		TOOLCHAIN_DEPS=(binutils gcc gcc-c++ gcc-gfortran libatomic)
+	fi
 	if [ "${AUDITWHEEL_ARCH}" == "x86_64" ]; then
 		TOOLCHAIN_DEPS+=(yasm)
 	fi

--- a/docker/tests/ctest/CMakeLists.txt
+++ b/docker/tests/ctest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.30)
 project(manylinux_ctest)
 include(CTest)
 


### PR DESCRIPTION
see https://discuss.python.org/t/packaging-support-for-riscv64/58475/9 & https://github.com/pypa/manylinux/discussions/1426#discussioncomment-13753925

fix #1773, only the aarch64 is added while waiting for #1725 to be fixed (& it's probably to early in the ecosystem anyway, having the aarch64 image is also an easier way to debug manylinux_2_39 than the slow qemu manylinux_2_39_riscv64)