### PR TITLE
break: remove manylinux_2_34_i686 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           reduced = [
               ("x86_64", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
-              ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
+              ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "musllinux_1_2")),
               ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
               ("s390x", "ubuntu-24.04", ("musllinux_1_2",)),
           ]

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ The manylinux project supports:
 
 - ``manylinux_2_28`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
-- ``manylinux_2_34`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
+- ``manylinux_2_34`` images for ``x86_64``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
 - ``musllinux_1_2`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le``, ``s390x`` and ``armv7l``.
 
@@ -107,7 +107,6 @@ See https://github.com/pypa/manylinux/issues/1725
 Toolchain: GCC 14
 
 - x86_64 image: ``quay.io/pypa/manylinux_2_34_x86_64``
-- i686 image: ``quay.io/pypa/manylinux_2_34_i686``
 - aarch64 image: ``quay.io/pypa/manylinux_2_34_aarch64``
 - ppc64le image: ``quay.io/pypa/manylinux_2_34_ppc64le``
 - s390x image: ``quay.io/pypa/manylinux_2_34_s390x``

--- a/deploy_multiarch.sh
+++ b/deploy_multiarch.sh
@@ -32,6 +32,7 @@ for IMAGE in "${IMAGES[@]}"; do
 
 	case ${IMAGE} in
 		manylinux_2_31) ARCHS=("armv7l");;
+		manylinux_2_34) ARCHS=("x86_64" "aarch64" "ppc64le" "s390x");;
 		musllinux_1_2) ARCHS=("x86_64" "i686" "aarch64" "armv7l" "ppc64le" "s390x");;
 		*) ARCHS=("x86_64" "i686" "aarch64" "ppc64le" "s390x");;
 	esac


### PR DESCRIPTION
The manylinux_2_34_i686 image has been added 3 days ago, is still in ALPHA and we're missing cache space on GHA.
Let's remove it for now, it'll be added again once possible.