### PR TITLE
fix: hide libsqlite3.so from system search folders

### DIFF
--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -54,13 +54,10 @@ elif [ "${BASE_POLICY}_${AUDITWHEEL_ARCH}" == "musllinux_armv7l" ]; then
 	CONFIGURE_ARGS+=(--build=arm-linux-musleabihf)
 fi
 
-SQLITE_PREFIX=$(find /opt/_internal -maxdepth 1 -name 'sqlite*')
-if [ "${SQLITE_PREFIX}" != "" ]; then
-	case "${CPYTHON_VERSION}" in
-		3.8.*|3.9.*|3.10.*) sed -i "s|/usr/local/include/sqlite3|/opt/_internal/sqlite3/include|g ; s|sqlite_extra_link_args = ()|sqlite_extra_link_args = ('-Wl,--enable-new-dtags,-rpath=/opt/_internal/sqlite3/lib',)|g" setup.py;;
-		*) ;;
-	esac
-fi
+case "${CPYTHON_VERSION}" in
+	3.8.*|3.9.*|3.10.*) sed -i "s|/usr/local/include/sqlite3|/opt/_internal/sqlite3/include|g ; s|sqlite_extra_link_args = ()|sqlite_extra_link_args = ('-Wl,--enable-new-dtags,-rpath=/opt/_internal/sqlite3/lib',)|g" setup.py;;
+	*) ;;
+esac
 
 OPENSSL_PREFIX=$(find /opt/_internal -maxdepth 1 -name 'openssl*')
 if [ "${OPENSSL_PREFIX}" != "" ]; then

--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -11,11 +11,7 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source-path=SCRIPTDIR
 source "${MY_DIR}/build_utils.sh"
 
-if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
-	PREFIX=/usr/local
-else
-	PREFIX=/opt/_internal/sqlite3
-fi
+PREFIX=/opt/_internal/sqlite3
 
 # Install a more recent SQLite3
 check_var "${SQLITE_AUTOCONF_ROOT}"
@@ -42,8 +38,12 @@ strip_ /manylinux-rootfs
 mkdir /manylinux-buildfs
 cp -rlf /manylinux-rootfs/* /manylinux-buildfs/
 
-if [ "${PREFIX}" == "/opt/_internal/sqlite3" ]; then
-	# python >= 3.11
-	mkdir -p /manylinux-buildfs/usr/local/lib/pkgconfig/
-	ln -s ${PREFIX}/lib/pkgconfig/sqlite3.pc /manylinux-buildfs/usr/local/lib/pkgconfig/sqlite3.pc
+# python >= 3.11
+mkdir -p /manylinux-buildfs/usr/local/lib/pkgconfig/
+ln -s ${PREFIX}/lib/pkgconfig/sqlite3.pc /manylinux-buildfs/usr/local/lib/pkgconfig/sqlite3.pc
+
+if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
+	# we still expose our custom libsqlite3 for dev in runtime images
+	mkdir -p /manylinux-rootfs/usr/local/lib/pkgconfig/
+	ln -s ${PREFIX}/lib/pkgconfig/sqlite3.pc /manylinux-rootfs/usr/local/lib/pkgconfig/sqlite3.pc
 fi

--- a/docker/tests/ctest/CMakeLists.txt
+++ b/docker/tests/ctest/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.14.7)
+cmake_minimum_required(VERSION 4.0)
 project(manylinux_ctest)
 include(CTest)
 
 # SQLite3 test Derived from CMake unit test for FindSQLite3
 # https://gitlab.kitware.com/cmake/cmake/-/tree/master/Tests/FindSQLite3/Test
-find_package(SQLite3 3.34 REQUIRED)
+find_package(SQLite3 3.50 REQUIRED)
 add_definitions(-DCMAKE_EXPECTED_SQLite3_VERSION="${SQLite3_VERSION}")
 add_executable(test_sqlite3 test_sqlite3.cpp)
 target_link_libraries(test_sqlite3 SQLite::SQLite3)

--- a/docker/tests/run_tests.sh
+++ b/docker/tests/run_tests.sh
@@ -62,7 +62,7 @@ for PYTHON in /opt/python/*/bin/python; do
 	if [ "${IMPLEMENTATION}" == "cpython" ]; then
 		# Make sure sqlite3 module can be loaded properly and is the manylinux version one
 		# c.f. https://github.com/pypa/manylinux/issues/1030
-		$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version); assert sqlite3.sqlite_version_info[0:2] >= (3, 31)'
+		$PYTHON -c 'import sqlite3; print(sqlite3.sqlite_version); assert sqlite3.sqlite_version_info[0:2] >= (3, 50)'
 		# Make sure tkinter module can be loaded properly
 		$PYTHON -c 'import tkinter; print(tkinter.TkVersion); assert tkinter.TkVersion >= 8.6'
 		# cpython shall be available as python
@@ -128,10 +128,6 @@ pipx run nox --version
 pipx install --pip-args='--no-input' nox
 nox --version
 tar --version | grep "GNU tar"
-# we stopped installing sqlite3 after manylinux_2_28 / musllinux_1_2
-if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
-	sqlite3 --version
-fi
 
 # check libcrypt.so.1 can be loaded by some system packages,
 # as LD_LIBRARY_PATH might not be enough.
@@ -143,6 +139,8 @@ if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ]; then
 fi
 
 if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "musllinux_1_2" ]; then
+	# we stopped installing sqlite3 after manylinux_2_28 / musllinux_1_2 & this is becoming an internal detail
+	/opt/_internal/sqlite3/bin/sqlite3 --version
 	# sqlite compilation tests, intended to ensure appropriate headers, pkg_config, etc.
 	# are available for downstream compile against installed tools
 	source_dir="${MY_DIR}/ctest"


### PR DESCRIPTION
fix #1795

The pkgconfig config file for the custom sqlite is still installed in /usr/local/lib not to break builds finding it this way.
It might break some users but better not to break the system. The custom sqlite3 should really be an internal detail but it was present before so keeping all the `-dev` related files in `/opt/_internal/sqlite3` for now (deprecation to be announced).