### PR TITLE
ci: use registry cache (on quay.io) instead of GHA cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Quay.io Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pypa/manylinux'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Restore cache
         if: github.event_name != 'workflow_dispatch' || fromJSON(github.event.inputs.useCache)
         uses: actions/cache/restore@v4
@@ -99,21 +107,6 @@ jobs:
 
       - name: Build
         run: ./build.sh
-
-      - name: Delete cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          KEY="buildx-cache-${{ matrix.policy }}-${{ matrix.platform }}"
-          gh cache delete ${KEY} || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
-        with:
-          path: .buildx-cache-${{ matrix.policy }}_${{ matrix.platform }}/*
-          key: buildx-cache-${{ matrix.policy }}-${{ matrix.platform }}
 
       - name: Deploy
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pypa/manylinux'


### PR DESCRIPTION
In order to reduce cache pressure issues with current GHA limits, move the cache to quay.io