### PR TITLE
Revert "break: remove manylinux_2_34_i686 image (#1796)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           reduced = [
               ("x86_64", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
-              ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "musllinux_1_2")),
+              ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
               ("s390x", "ubuntu-24.04", ("musllinux_1_2",)),
           ]

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ The manylinux project supports:
 
 - ``manylinux_2_28`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
-- ``manylinux_2_34`` images for ``x86_64``, ``aarch64``, ``ppc64le`` and ``s390x``.
+- ``manylinux_2_34`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
 - ``musllinux_1_2`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le``, ``s390x`` and ``armv7l``.
 
@@ -107,6 +107,7 @@ See https://github.com/pypa/manylinux/issues/1725
 Toolchain: GCC 14
 
 - x86_64 image: ``quay.io/pypa/manylinux_2_34_x86_64``
+- i686 image: ``quay.io/pypa/manylinux_2_34_i686``
 - aarch64 image: ``quay.io/pypa/manylinux_2_34_aarch64``
 - ppc64le image: ``quay.io/pypa/manylinux_2_34_ppc64le``
 - s390x image: ``quay.io/pypa/manylinux_2_34_s390x``

--- a/deploy_multiarch.sh
+++ b/deploy_multiarch.sh
@@ -32,7 +32,6 @@ for IMAGE in "${IMAGES[@]}"; do
 
 	case ${IMAGE} in
 		manylinux_2_31) ARCHS=("armv7l");;
-		manylinux_2_34) ARCHS=("x86_64" "aarch64" "ppc64le" "s390x");;
 		musllinux_1_2) ARCHS=("x86_64" "i686" "aarch64" "armv7l" "ppc64le" "s390x");;
 		*) ARCHS=("x86_64" "i686" "aarch64" "ppc64le" "s390x");;
 	esac


### PR DESCRIPTION
This reverts commit 87542c8a6c2590b2c3152fb6f9471d1c63bf1592.

There should be no issues with cache anymore.