### PR TITLE
feat: use cross-compilation to build images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
               ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
               ("riscv64", "ubuntu-24.04", ("manylinux_2_39", "musllinux_1_2")),
+              ("ppc64le", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2",)),
+              ("s390x", "ubuntu-24.04", ("musllinux_1_2",)),
           ]
           expanded = [{"policy": policy, "platform": platform, "runner": runner} for platform, runner, policies in reduced for policy in policies]
           print(json.dumps(expanded, indent=2))
@@ -79,7 +81,7 @@ jobs:
           fetch-depth: 50
 
       - name: Set up QEMU
-        if: matrix.platform == 'riscv64'
+        if: matrix.platform == 'ppc64le' || matrix.platform == 'riscv64' || matrix.platform == 's390x'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,10 @@ jobs:
    include:
     - arch: s390x
       env: POLICY="manylinux2014" PLATFORM="s390x"
-    - arch: ppc64le
-      env: POLICY="manylinux2014" PLATFORM="ppc64le"
     - arch: s390x
       env: POLICY="manylinux_2_28" PLATFORM="s390x"
-    - arch: ppc64le
-      env: POLICY="manylinux_2_28" PLATFORM="ppc64le"
     - arch: s390x
       env: POLICY="manylinux_2_34" PLATFORM="s390x"
-    - arch: ppc64le
-      env: POLICY="manylinux_2_34" PLATFORM="ppc64le"
-    - arch: s390x
-      env: POLICY="musllinux_1_2" PLATFORM="s390x"
-    - arch: ppc64le
-      env: POLICY="musllinux_1_2" PLATFORM="ppc64le"
 
 before_install:
   - if [ -d "${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM}" ]; then cp -rlf ${HOME}/buildx-cache/.buildx-cache-${POLICY}_${PLATFORM} ./; fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,12 @@ ARG PLATFORM=x86_64
 ARG DEVTOOLSET_ROOTPATH=/opt/rh/gcc-toolset-14/root
 ARG LD_LIBRARY_PATH_ARG=${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst
 ARG PREPEND_PATH=/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:
+ARG MANYLINUX_BUILDARCH=${BUILDARCH}
+ARG MANYLINUX_DISABLE_CLANG=0
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=0
 
-FROM $BASEIMAGE AS runtime_base
+
+FROM $BASEIMAGE AS runtime_base_packages
 ARG POLICY
 ARG PLATFORM
 ARG DEVTOOLSET_ROOTPATH
@@ -42,29 +46,49 @@ RUN manylinux-entrypoint /build_scripts/install-runtime-packages.sh && rm -rf /b
 
 COPY build_scripts/build_utils.sh /build_scripts/
 
+
+# prepare cross-compilation support
+FROM --platform=linux/${MANYLINUX_BUILDARCH} ghcr.io/mayeut/static-clang:20.1.8.0 AS static_clang_bin
+FROM runtime_base_packages AS static_clang_prepare
+ARG MANYLINUX_DISABLE_CLANG
+COPY build_scripts/install-clang-static.sh /build_scripts/
+RUN --mount=type=bind,target=/clang,from=static_clang_bin \
+    mkdir -p /tmp/cross-compiler && \
+    cp -rf /clang/opt/clang/* /tmp/cross-compiler/ && \
+    /build_scripts/install-clang-static.sh /tmp/cross-compiler
+FROM scratch AS static_clang
+COPY --from=static_clang_prepare /tmp/cross-compiler /
+
+
+FROM runtime_base_packages AS runtime_base
 COPY build_scripts/install-autoconf.sh /build_scripts/
-RUN export AUTOCONF_ROOT=autoconf-2.72 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export AUTOCONF_ROOT=autoconf-2.72 && \
     export AUTOCONF_HASH=afb181a76e1ee72832f6581c0eddf8df032b83e2e0239ef79ebedc4467d92d6e && \
     export AUTOCONF_DOWNLOAD_URL=http://ftp.gnu.org/gnu/autoconf && \
-    manylinux-entrypoint /build_scripts/install-autoconf.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/install-autoconf.sh
 
 COPY build_scripts/install-automake.sh /build_scripts/
-RUN export AUTOMAKE_ROOT=automake-1.18.1 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export AUTOMAKE_ROOT=automake-1.18.1 && \
     export AUTOMAKE_HASH=63e585246d0fc8772dffdee0724f2f988146d1a3f1c756a3dc5cfbefa3c01915 && \
     export AUTOMAKE_DOWNLOAD_URL=http://ftp.gnu.org/gnu/automake && \
-    manylinux-entrypoint /build_scripts/install-automake.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/install-automake.sh
 
 COPY build_scripts/install-libtool.sh /build_scripts/
-RUN export LIBTOOL_ROOT=libtool-2.5.4 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export LIBTOOL_ROOT=libtool-2.5.4 && \
     export LIBTOOL_HASH=da8ebb2ce4dcf46b90098daf962cffa68f4b4f62ea60f798d0ef12929ede6adf && \
     export LIBTOOL_DOWNLOAD_URL=http://ftp.gnu.org/gnu/libtool && \
-    manylinux-entrypoint /build_scripts/install-libtool.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/install-libtool.sh
 
 COPY build_scripts/install-libxcrypt.sh /build_scripts/
-RUN export LIBXCRYPT_VERSION=4.4.38 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export LIBXCRYPT_VERSION=4.4.38 && \
     export LIBXCRYPT_HASH=80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6 && \
     export LIBXCRYPT_DOWNLOAD_URL=https://github.com/besser82/libxcrypt/releases/download && \
-    manylinux-entrypoint /build_scripts/install-libxcrypt.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/install-libxcrypt.sh
+
 
 FROM runtime_base AS build_base
 COPY build_scripts/install-build-packages.sh /build_scripts/
@@ -73,41 +97,50 @@ RUN manylinux-entrypoint /build_scripts/install-build-packages.sh
 
 FROM build_base AS build_git
 COPY build_scripts/build-curl.sh /build_scripts/
-RUN export CURL_ROOT=curl-8.15.0 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export CURL_ROOT=curl-8.15.0 && \
     export CURL_HASH=d85cfc79dc505ff800cb1d321a320183035011fa08cb301356425d86be8fc53c && \
     export CURL_DOWNLOAD_URL=https://curl.haxx.se/download && \
-    manylinux-entrypoint /build_scripts/build-curl.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-curl.sh
 COPY build_scripts/build-git.sh /build_scripts/
-RUN export GIT_ROOT=git-2.51.0 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export GIT_ROOT=git-2.51.0 && \
     export GIT_HASH=3d531799d2cf2cac8e294ec6e3229e07bfca60dc6c783fe69e7712738bef7283 && \
     export GIT_DOWNLOAD_URL=https://www.kernel.org/pub/software/scm/git && \
-    manylinux-entrypoint /build_scripts/build-git.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-git.sh
+
 
 FROM build_base AS build_sqlite3
 COPY build_scripts/build-sqlite3.sh /build_scripts/
-RUN export SQLITE_AUTOCONF_ROOT=sqlite-autoconf-3500400 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export SQLITE_AUTOCONF_ROOT=sqlite-autoconf-3500400 && \
     export SQLITE_AUTOCONF_HASH=a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18 && \
     export SQLITE_AUTOCONF_DOWNLOAD_URL=https://www.sqlite.org/2025 && \
-    manylinux-entrypoint /build_scripts/build-sqlite3.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-sqlite3.sh
+
 
 FROM build_base AS build_tcl_tk
 COPY build_scripts/build-tcltk.sh /build_scripts/
-RUN export TCL_ROOT=tcl8.6.17 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export TCL_ROOT=tcl8.6.17 && \
     export TCL_HASH=a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31 && \
     export TCL_DOWNLOAD_URL=https://prdownloads.sourceforge.net/tcl && \
     export TK_ROOT=tk8.6.17 && \
     export TK_HASH=e4982df6f969c08bf9dd858a6891059b4a3f50dc6c87c10abadbbe2fc4838946 && \
-    manylinux-entrypoint /build_scripts/build-tcltk.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-tcltk.sh
+
 
 FROM build_base AS build_mpdecimal
 COPY build_scripts/build-mpdecimal.sh /build_scripts/
-RUN export MPDECIMAL_ROOT=mpdecimal-4.0.0 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export MPDECIMAL_ROOT=mpdecimal-4.0.0 && \
     export MPDECIMAL_HASH=942445c3245b22730fd41a67a7c5c231d11cb1b9936b9c0f76334fb7d0b4468c && \
     export MPDECIMAL_DOWNLOAD_URL=https://www.bytereef.org/software/mpdecimal/releases && \
-    manylinux-entrypoint /build_scripts/build-mpdecimal.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-mpdecimal.sh
 
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/sigstore/cosign/cosign:v2.5.0 AS cosign-bin
+
 
 FROM build_base AS build_cpython
 COPY --from=build_tcl_tk /manylinux-buildfs /
@@ -115,39 +148,60 @@ COPY --from=build_mpdecimal /manylinux-buildfs /
 COPY --from=build_sqlite3 /manylinux-buildfs /
 RUN if command -v apk >/dev/null 2>&1; then ldconfig /; else ldconfig; fi
 COPY build_scripts/build-openssl.sh /build_scripts/
-RUN export OPENSSL_ROOT=openssl-3.5.2 && \
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    export OPENSSL_ROOT=openssl-3.5.2 && \
     export OPENSSL_HASH=c53a47e5e441c930c3928cf7bf6fb00e5d129b630e0aa873b08258656e7345ec && \
     export OPENSSL_DOWNLOAD_URL=https://github.com/openssl/openssl/releases/download/${OPENSSL_ROOT} && \
-    manylinux-entrypoint /build_scripts/build-openssl.sh
+    /tmp/cross-compiler/entrypoint /build_scripts/build-openssl.sh
 COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
 COPY build_scripts/build-cpython.sh /build_scripts/
 
+
 FROM build_cpython AS build_cpython38
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh lukasz@langa.pl https://github.com/login/oauth 3.8.20
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh lukasz@langa.pl https://github.com/login/oauth 3.8.20
 
 FROM build_cpython AS build_cpython39
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh lukasz@langa.pl https://github.com/login/oauth 3.9.23
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh lukasz@langa.pl https://github.com/login/oauth 3.9.23
 
 FROM build_cpython AS build_cpython310
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh pablogsal@python.org https://accounts.google.com 3.10.18
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh pablogsal@python.org https://accounts.google.com 3.10.18
 
 FROM build_cpython AS build_cpython311
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh pablogsal@python.org https://accounts.google.com 3.11.13
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh pablogsal@python.org https://accounts.google.com 3.11.13
 
 FROM build_cpython AS build_cpython312
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.12.11
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.12.11
 
 FROM build_cpython AS build_cpython313
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.13.7
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.13.7
 
 FROM build_cpython AS build_cpython313_nogil
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.13.7 nogil
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh thomas@python.org https://accounts.google.com 3.13.7 nogil
 
 FROM build_cpython AS build_cpython314
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh hugo@python.org https://github.com/login/oauth 3.14.0rc2
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh hugo@python.org https://github.com/login/oauth 3.14.0rc2
 
 FROM build_cpython AS build_cpython314_nogil
-RUN manylinux-entrypoint /build_scripts/build-cpython.sh hugo@python.org https://github.com/login/oauth 3.14.0rc2 nogil
+ARG MANYLINUX_DISABLE_CLANG_FOR_CPYTHON
+RUN --mount=type=bind,from=static_clang,target=/tmp/cross-compiler,ro \
+    /tmp/cross-compiler/entrypoint /build_scripts/build-cpython.sh hugo@python.org https://github.com/login/oauth 3.14.0rc2 nogil
+
 
 FROM runtime_base
 COPY --from=build_tcl_tk /manylinux-rootfs /

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -45,11 +45,16 @@ if [ "$(nproc)" -ge 2 ]; then
 	PARALLEL_BUILDS=-j2
 fi
 
+LIBATOMIC=
+if [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
+	LIBATOMIC=-latomic
+fi
+
 fetch_source "${OPENSSL_ROOT}.tar.gz" "${OPENSSL_DOWNLOAD_URL}"
 check_sha256sum "${OPENSSL_ROOT}.tar.gz" "${OPENSSL_HASH}"
 tar -xzf "${OPENSSL_ROOT}.tar.gz"
 pushd "${OPENSSL_ROOT}"
-./Configure "--prefix=${PREFIX}" "--openssldir=${PREFIX}" --libdir=lib CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS} -Wl,-rpath,\$(LIBRPATH)" > /dev/null
+./Configure "--prefix=${PREFIX}" "--openssldir=${PREFIX}" --libdir=lib no-afalgeng CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS} -Wl,-rpath,\$(LIBRPATH) ${LIBATOMIC}" > /dev/null
 make ${PARALLEL_BUILDS} > /dev/null
 make install_sw > /dev/null
 popd

--- a/docker/build_scripts/install-clang-static.sh
+++ b/docker/build_scripts/install-clang-static.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Install packages that will be needed at runtime
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+# Set build environment variables
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+# shellcheck source-path=SCRIPTDIR
+source "${MY_DIR}/build_utils.sh"
+
+case "${BASE_POLICY}-${AUDITWHEEL_ARCH}" in
+	manylinux-armv7l) TARGET_TRIPLE=armv7-unknown-linux-gnueabihf;;
+	musllinux-armv7l) TARGET_TRIPLE=armv7-alpine-linux-musleabihf;;
+	manylinux-ppc64le) TARGET_TRIPLE=powerpc64le-unknown-linux-gnu;;
+	musllinux-ppc64le) TARGET_TRIPLE=powerpc64le-alpine-linux-musl;;
+	manylinux-*) TARGET_TRIPLE=${AUDITWHEEL_ARCH}-unknown-linux-gnu;;
+	musllinux-*) TARGET_TRIPLE=${AUDITWHEEL_ARCH}-alpine-linux-musl;;
+esac
+case "${AUDITWHEEL_ARCH}" in
+	riscv64) M_ARCH="-march=rv64gc";;
+	x86_64) M_ARCH="-march=x86-64";;
+	armv7l) M_ARCH="-march=armv7a";;
+	i686) M_ARCH="-march=i686";;
+esac
+GCC_TRIPLE=$(gcc -dumpmachine)
+
+TOOLCHAIN_PATH="$1"
+ln -s clang "${TOOLCHAIN_PATH}/bin/gcc"
+ln -s clang "${TOOLCHAIN_PATH}/bin/cc"
+ln -s clang-cpp "${TOOLCHAIN_PATH}/bin/cpp"
+ln -s clang++ "${TOOLCHAIN_PATH}/bin/g++"
+ln -s clang++ "${TOOLCHAIN_PATH}/bin/c++"
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/${AUDITWHEEL_PLAT}.cfg"
+	-target ${TARGET_TRIPLE}
+	${M_ARCH:-}
+	--gcc-toolchain=${DEVTOOLSET_ROOTPATH:-}/usr
+	--gcc-triple=${GCC_TRIPLE}
+EOF
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+	-fuse-ld=lld
+EOF
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang++.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+	-fuse-ld=lld
+EOF
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang-cpp.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+EOF
+
+cat<<EOF >"${TOOLCHAIN_PATH}/entrypoint"
+#!/bin/bash
+
+set -eu
+export MANYLINUX_DISABLE_CLANG=${MANYLINUX_DISABLE_CLANG}
+if [ ${MANYLINUX_DISABLE_CLANG} -eq 0 ] && [ \${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON:-0} -eq 0 ]; then
+	export PATH="${TOOLCHAIN_PATH}/bin:\${PATH}"
+fi
+exec manylinux-entrypoint "\$@"
+EOF
+
+chmod +x "${TOOLCHAIN_PATH}/entrypoint"

--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -22,6 +22,11 @@ check_var "${LIBXCRYPT_HASH}"
 check_var "${LIBXCRYPT_DOWNLOAD_URL}"
 LIBXCRYPT_ROOT="libxcrypt-${LIBXCRYPT_VERSION}"
 
+if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ]; then
+	# revert to using ld as ldd does not like the version script
+	MANYLINUX_LDFLAGS="-fuse-ld=ld ${MANYLINUX_LDFLAGS}"
+fi
+
 fetch_source "${LIBXCRYPT_ROOT}.tar.xz" "${LIBXCRYPT_DOWNLOAD_URL}/v${LIBXCRYPT_VERSION}"
 check_sha256sum "${LIBXCRYPT_ROOT}.tar.xz" "${LIBXCRYPT_HASH}"
 tar xfJ "${LIBXCRYPT_ROOT}.tar.xz"


### PR DESCRIPTION
This PR uses a statically built Clang in order to enable "cross-compilation" although seen from all scripts, this behaves as a native compilation.
A full build that was taking more than 5 hours with QEMU takes less than 2 hours with this cross-compilation method.

Given CPython has different [support level for gcc than clang](https://peps.python.org/pep-0011/#support-tiers), we do respect this when building CPython, the default is as follows:
- use Clang to build all libraries/tools when the build machine is x86_64/aarch64 (this is was we use on GHA)
- use GCC to build CPython if GCC has a higher level of support according to PEP11, otherwise, use Clang

Everything can be overridden.

This only configurations that are still too slow and are left on Travis CI are manylinux s390x images for which CPython only has some level of support when using GCC.