### PR TITLE
fix: warn on error rather than fail in update workflow

### DIFF
--- a/tools/update_native_dependencies.py
+++ b/tools/update_native_dependencies.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import re
 import subprocess
+import sys
 from collections import defaultdict
 from pathlib import Path
 
@@ -206,9 +207,15 @@ def main():
     _update_sqlite(args.dry_run)
     _update_tcltk(args.dry_run)
     for tool in ["autoconf", "automake", "libtool", "git", "openssl", "curl"]:
-        _update_with_root(tool, args.dry_run)
+        try:
+            _update_with_root(tool, args.dry_run)
+        except Exception as e:
+            print(f"::warning::update: {e}\n", file=sys.stderr)
     for tool in ["libxcrypt"]:
-        _update_with_gh(tool, args.dry_run)
+        try:
+            _update_with_gh(tool, args.dry_run)
+        except Exception as e:
+            print(f"::warning::update: {e}\n", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
c.f. failure in https://github.com/pypa/manylinux/actions/runs/17866140988/job/50808855958
```python-traceback
Traceback (most recent call last):
  File "/home/runner/work/manylinux/manylinux/tools/update_native_dependencies.py", line 215, in <module>
    main()
  File "/home/runner/work/manylinux/manylinux/tools/update_native_dependencies.py", line 209, in main
    _update_with_root(tool, args.dry_run)
  File "/home/runner/work/manylinux/manylinux/tools/update_native_dependencies.py", line 97, in _update_with_root
    sha256 = _sha256(f"{url}/{root}.tar.gz")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/manylinux/manylinux/tools/update_native_dependencies.py", line 24, in _sha256
    response.raise_for_status()
  File "/home/runner/work/manylinux/manylinux/.nox/update_native_dependencies/lib/python3.12/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://ftp.gnu.org/gnu/libtool/libtool-2.6.0.tar.gz
```