### PR TITLE
build manylinux_2_35 for riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
               ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "manylinux_2_39", "musllinux_1_2")),
               ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
-              ("riscv64", "ubuntu-24.04", ("manylinux_2_39", "musllinux_1_2")),
+              ("riscv64", "ubuntu-24.04", ("manylinux_2_39", "musllinux_1_2", "manylinux_2_35")),
           ]
           expanded = [{"policy": policy, "platform": platform, "runner": runner} for platform, runner, policies in reduced for policy in policies]
           print(json.dumps(expanded, indent=2))


### PR DESCRIPTION
Hi there.

I've recently been trying to build PyPI packages for riscv64 that are compatible with Ubuntu 22. I found that manylinux_2_35 meets the relevant usage requirements, so I'm submitting this PR in hopes of obtaining an officially available image.

Ubuntu 22.04 has an available [image](https://hub.docker.com/layers/library/ubuntu/22.04/images/sha256-ed85bae8cad985d4310aee54e91f24f9992a68d9389dcbfb84f725fa55706735) on Docker Hub, and this image already has riscv64-related sources configured, allowing most software to be installed via apt. I ran the related builds in my fork, and here are the [execution results](https://github.com/ffgan/manylinux/actions/runs/17979320481/job/51140886830). The results look good, so we can consider adding support for the related image.

If there are any issues, please feel free to contact me at any time.



---

**Other Info**

Co-authored by: nijincheng@iscas.ac.cn;