### PR TITLE
fix: sysconfig

### DIFF
--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -73,6 +73,8 @@ unset _PYTHON_HOST_PLATFORM
 # configure with hardening options only for the interpreter & stdlib C extensions
 # do not change the default for user built extension (yet?)
 ./configure \
+	CC=gcc \
+	CXX=g++ \
 	CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}" \
 	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS} ${LDFLAGS_EXTRA}" \
 	"--prefix=${PREFIX}" "${CONFIGURE_ARGS[@]}" > /dev/null


### PR DESCRIPTION
CXX sysconfig value was clang++ in some cases starting with Python 3.14 only.
Let's force CC/CXX in order to always  have working values in sysconfig.