### PR TITLE
fix: use symlinks & strip git while installing

### DIFF
--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -44,13 +44,20 @@ fetch_source "${GIT_ROOT}.tar.gz" "${GIT_DOWNLOAD_URL}"
 check_sha256sum "${GIT_ROOT}.tar.gz" "${GIT_HASH}"
 tar -xzf "${GIT_ROOT}.tar.gz"
 pushd "${GIT_ROOT}"
-make install prefix=/usr/local NO_GETTEXT=1 NO_TCLTK=1 DESTDIR=/manylinux-rootfs CSPRNG_METHOD=${CSPRNG_METHOD} CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}"
+make install \
+	prefix=/usr/local \
+	NO_GETTEXT=1 \
+	NO_TCLTK=1 \
+	INSTALL_SYMLINKS=1 \
+	INSTALL_STRIP=-s \
+	DESTDIR=/manylinux-rootfs \
+	CSPRNG_METHOD=${CSPRNG_METHOD} \
+	CPPFLAGS="${MANYLINUX_CPPFLAGS}" \
+	CFLAGS="${MANYLINUX_CFLAGS}" \
+	CXXFLAGS="${MANYLINUX_CXXFLAGS}" \
+	LDFLAGS="${MANYLINUX_LDFLAGS}"
 popd
 rm -rf "${GIT_ROOT}" "${GIT_ROOT}.tar.gz"
-
-
-# Strip what we can
-strip_ /manylinux-rootfs
 
 # Install
 cp -rlf /manylinux-rootfs/* /


### PR DESCRIPTION
For some reason, the size of the images increased a lot around the time we moved to building git with clang but, local tests show that it does not seem related.
Rework git build configuration to reduce image size.

According to a local build, Docker Desktop shows image size going from 3.05 GB to 2.21 GB for `quay.io/pypa/manylinux_2_28_aarch64` with this PR.