### PR TITLE
feat: manylinux_2_35_armv7l

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
               ("x86_64", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("aarch64", "ubuntu-24.04-arm", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "manylinux_2_39", "musllinux_1_2")),
               ("i686", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
-              ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "musllinux_1_2")),
+              ("armv7l", "ubuntu-24.04-arm", ("manylinux_2_31", "manylinux_2_35", "musllinux_1_2")),
               ("ppc64le", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),
               ("riscv64", "ubuntu-24.04", ("manylinux_2_39", "musllinux_1_2")),
               ("s390x", "ubuntu-24.04", ("manylinux2014", "manylinux_2_28", "manylinux_2_34", "musllinux_1_2")),

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,11 @@ The manylinux project supports:
 
 - ``manylinux_2_28`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
 
+- ``manylinux_2_31`` images for ``armv7l``.
+
 - ``manylinux_2_34`` images for ``x86_64``, ``i686``, ``aarch64``, ``ppc64le`` and ``s390x``.
+
+- ``manylinux_2_35`` images for ``armv7l``.
 
 - ``manylinux_2_39`` images for ``aarch64`` and ``riscv64``.
 
@@ -112,6 +116,36 @@ distros using glibc 2.39 or later, including:
 - CentOS/RHEL 10+
 
 
+manylinux_2_35 (Ubuntu 22.04 based) - armv7l only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Caveat:
+
+Only Debian derivatives are available for armv7l. They do not provide recent builds of the GCC toolchain
+compatible with a vanilla install of the distribution. As such, we only get the GCC toolchain shipped with
+the base distribution.
+
+The package manager & packages names are different than what is found on other manylinux images.
+Other images are using RHEL derivatives only for now so using yum/dnf as a package manager and RHEL like
+packages names this image is using apt and Debian like packages names.
+
+If one depends on let's say OpenSSL development package, then, the commands to issue to install it are a bit different:
+
+- ``dnf -y install openssl-devel`` on RHEL derivatives
+- ``apt-get update && apt-get install -y libssl-dev`` on Debian derivatives
+
+
+Toolchain: GCC 11
+
+- armv7l image: ``quay.io/pypa/manylinux_2_35_armv7l``
+
+Built wheels are also expected to be compatible with other
+distros using glibc 2.35 or later, including:
+
+- Debian 12+
+- Ubuntu 22.04+
+
+
 manylinux_2_34 (AlmaLinux 9 based) - ALPHA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -140,8 +174,8 @@ distros using glibc 2.34 or later, including:
 - CentOS/RHEL 9+
 
 
-manylinux_2_31 (Ubuntu 20.04 based) - armv7l only - BETA
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+manylinux_2_31 (Ubuntu 20.04 based) - armv7l only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Caveat:
 

--- a/deploy_multiarch.sh
+++ b/deploy_multiarch.sh
@@ -2,19 +2,20 @@
 
 set -euo pipefail
 
-IMAGES=(manylinux2014 manylinux_2_28 manylinux_2_31 manylinux_2_34 manylinux_2_39 musllinux_1_2)
+IMAGES=(manylinux2014 manylinux_2_28 manylinux_2_31 manylinux_2_34 manylinux_2_35 manylinux_2_39 musllinux_1_2)
 
 podman login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 for IMAGE in "${IMAGES[@]}"; do
 	echo "::group::${IMAGE} check"
-	LAST_TAG="$(oras repo tags --last "2025.06.08-1" "quay.io/pypa/${IMAGE}" | tail -2 | head -1)"
+	LAST_TAG="$(oras repo tags --last "2025.11.08-2" "quay.io/pypa/${IMAGE}" | tail -2 | head -1)"
 	if [ "${LAST_TAG}" == "" ]; then
-		 LAST_TAG=2025.06.08-1
+		 LAST_TAG=2025.11.08-2
 	fi
 	echo "last tag is ${LAST_TAG}"
 	case ${IMAGE} in
 		manylinux_2_31) REF_IMAGE=manylinux_2_31_armv7l;;
+		manylinux_2_35) REF_IMAGE=manylinux_2_35_armv7l;;
 		manylinux_2_39) REF_IMAGE=manylinux_2_39_aarch64;;
 		*) REF_IMAGE=${IMAGE}_x86_64;;
 	esac
@@ -33,6 +34,7 @@ for IMAGE in "${IMAGES[@]}"; do
 
 	case ${IMAGE} in
 		manylinux_2_31) ARCHS=("armv7l");;
+		manylinux_2_35) ARCHS=("armv7l");;
 		manylinux_2_39) ARCHS=("aarch64" "riscv64");;
 		musllinux_1_2) ARCHS=("x86_64" "i686" "aarch64" "armv7l" "ppc64le" "s390x" "riscv64");;
 		*) ARCHS=("x86_64" "i686" "aarch64" "ppc64le" "s390x");;


### PR DESCRIPTION
Ubuntu 20.04 standard support is over.
Let's get an armv7l image that still gets standard support and with a more recent gcc toolchain.