### PR TITLE
feat: use gcc-15 when possible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ for repeatable builds.
 manylinux_2_39 (AlmaLinux/RockyLinux 10 based) - ALPHA
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Toolchain: GCC 14
+Toolchain: GCC 15
 
 - aarch64 image: ``quay.io/pypa/manylinux_2_39_aarch64``
 - riscv64 image: ``quay.io/pypa/manylinux_2_39_riscv64``
@@ -157,7 +157,7 @@ grafted into a wheel, will fail to run on older hardware. There's no PEP to hand
 yet when it comes to packaging or installing wheels. Auditwheel doesn't detect this either.
 See https://github.com/pypa/manylinux/issues/1725
 
-Toolchain: GCC 14
+Toolchain: GCC 15
 
 - x86_64 image: ``quay.io/pypa/manylinux_2_34_x86_64``
 - i686 image: ``quay.io/pypa/manylinux_2_34_i686``
@@ -207,7 +207,7 @@ distros using glibc 2.31 or later, including:
 manylinux_2_28 (AlmaLinux 8 based)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Toolchain: GCC 14
+Toolchain: GCC 15
 
 - x86_64 image: ``quay.io/pypa/manylinux_2_28_x86_64``
 - i686 image: ``quay.io/pypa/manylinux_2_28_i686``
@@ -284,10 +284,10 @@ Toolchain: GCC 4.8
 - i686 image: ``quay.io/pypa/manylinux1_i686``
 
 
-musllinux_1_2 (Alpine Linux 3.22 based, 3.13+ compatible)
+musllinux_1_2 (Alpine Linux 3.23 based, 3.13+ compatible)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Toolchain: GCC 14
+Toolchain: GCC 15
 
 - x86_64 image: ``quay.io/pypa/musllinux_1_2_x86_64``
 - i686 image: ``quay.io/pypa/musllinux_1_2_i686``

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ if [ "${POLICY}" == "manylinux2014" ]; then
 	fi
 elif [ "${POLICY}" == "manylinux_2_28" ]; then
 	BASEIMAGE="quay.io/almalinuxorg/almalinux:8"
-	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-14/root"
+	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-15/root"
 	PREPEND_PATH="${DEVTOOLSET_ROOTPATH}/usr/bin:"
 	LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
 elif [ "${POLICY}" == "manylinux_2_31" ]; then
@@ -45,7 +45,7 @@ elif [ "${POLICY}" == "manylinux_2_31" ]; then
 	LD_LIBRARY_PATH_ARG=
 elif [ "${POLICY}" == "manylinux_2_34" ]; then
 	BASEIMAGE="quay.io/almalinuxorg/almalinux:9"
-	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-14/root"
+	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-15/root"
 	PREPEND_PATH="/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:"
 	LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
 elif [ "${POLICY}" == "manylinux_2_35" ]; then
@@ -59,15 +59,11 @@ elif [ "${POLICY}" == "manylinux_2_39" ]; then
 		x86_64) GOARCH="amd64/v2";;
 		riscv64) BASEIMAGE="rockylinux/rockylinux:10";;
 	esac
-	# TODO enable gcc-toolset-15 once available (probably in 10.1)
-	# DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-15/root"
-	# PREPEND_PATH="/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:"
-	# LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
-	DEVTOOLSET_ROOTPATH=
-	PREPEND_PATH=
-	LD_LIBRARY_PATH_ARG=
+	DEVTOOLSET_ROOTPATH="/opt/rh/gcc-toolset-15/root"
+	PREPEND_PATH="/usr/local/bin:${DEVTOOLSET_ROOTPATH}/usr/bin:"
+	LD_LIBRARY_PATH_ARG="${DEVTOOLSET_ROOTPATH}/usr/lib64:${DEVTOOLSET_ROOTPATH}/usr/lib:${DEVTOOLSET_ROOTPATH}/usr/lib64/dyninst:${DEVTOOLSET_ROOTPATH}/usr/lib/dyninst"
 elif [ "${POLICY}" == "musllinux_1_2" ]; then
-	BASEIMAGE="alpine:3.22"
+	BASEIMAGE="alpine:3.23"
 	DEVTOOLSET_ROOTPATH=
 	PREPEND_PATH=
 	LD_LIBRARY_PATH_ARG=

--- a/docker/build_scripts/finalize.sh
+++ b/docker/build_scripts/finalize.sh
@@ -106,8 +106,3 @@ LC_ALL=C "${MY_DIR}/update-system-packages.sh"
 
 # wrap compilers (see https://github.com/pypa/manylinux/issues/1725)
 "${MY_DIR}/install-gcc-wrapper.sh"
-
-# patch libstdc++.so  (see https://github.com/pypa/manylinux/issues/1760)
-if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_34" ]; then
-	find "${DEVTOOLSET_ROOTPATH}" -name 'libstdc++.so' -exec sed -i 's/INPUT\s*(\s*\([^ ]\+\)\s*\([^ ]\+\)\s*)/INPUT ( \1 \2 \1 )/g' {} \;
-fi

--- a/docker/build_scripts/install-runtime-packages.sh
+++ b/docker/build_scripts/install-runtime-packages.sh
@@ -128,13 +128,7 @@ elif [ "${OS_ID_LIKE}" == "rhel" ]; then
 		dnf config-manager --set-enabled crb
 	fi
 	dnf -y upgrade
-	if [ "${AUDITWHEEL_POLICY}" == "manylinux_2_28" ] || [ "${AUDITWHEEL_POLICY}" == "manylinux_2_34" ]; then
-		TOOLCHAIN_DEPS=(gcc-toolset-14-binutils gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-gcc-gfortran gcc-toolset-14-libatomic-devel)
-	else
-		# TODO enable gcc-toolset-15 once available (probably in 10.1)
-		# TOOLCHAIN_DEPS=(gcc-toolset-15-binutils gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-gcc-gfortran gcc-toolset-15-libatomic-devel)
-		TOOLCHAIN_DEPS=(binutils gcc gcc-c++ gcc-gfortran libatomic)
-	fi
+	TOOLCHAIN_DEPS=(gcc-toolset-15-binutils gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ gcc-toolset-15-gcc-gfortran gcc-toolset-15-libatomic-devel)
 elif [ "${OS_ID_LIKE}" == "debian" ]; then
 	TOOLCHAIN_DEPS+=(binutils gcc g++ gfortran libatomic1)
 	BASE_TOOLS+=(gpg gpg-agent hardlink hostname locales xz-utils)


### PR DESCRIPTION
Close #1878

All supported images - except manylinux2014 ones - now use gcc-15.
musllinux_1_2 moves to Alpine Linux 3.23 in order to achieve this.

Keeping in  draft while waiting for Alpine Linux 3.23 availability.