### PR TITLE
feat: use clang for manylinux_s390x, gcc is too slow

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,7 +113,7 @@ if [ "${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON:-}" == "" ]; then
 		case "${PLATFORM}" in
 			aarch64|x86_64) MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1;; # gcc is Tier-1, clang is Tier-2
 			armv7l) MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1;; # gcc is Tier-3, clang not supported at all
-			s390x) MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1;; # gcc is Tier-3, clang not supported at all
+			# s390x) MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1;; # gcc is Tier-3, clang not supported at all, gcc is too slow, use clang anyway
 			*) ;;
 		esac
 	fi


### PR DESCRIPTION
manylinux_s390x uses native gcc (Tier-3) but it's too slow on GHA and we will be reaching job time limit with CPython 3.15. Move to clang on s390x in order to reduce build time even though it's not supported by CPython.