### PR TITLE
chore: consolidate source fetching and checksum handling

### DIFF
--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -27,8 +27,8 @@ function pyver_dist_dir {
 }
 
 CPYTHON_DIST_DIR=$(pyver_dist_dir "${CPYTHON_VERSION}")
-fetch_source "Python-${CPYTHON_VERSION}.tar.xz" "${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}"
-fetch_source "Python-${CPYTHON_VERSION}.tar.xz.sigstore" "${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}"
+fetch_source "Python-${CPYTHON_VERSION}.tar.xz" "${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}" skip-hash
+fetch_source "Python-${CPYTHON_VERSION}.tar.xz.sigstore" "${CPYTHON_DOWNLOAD_URL}/${CPYTHON_DIST_DIR}" skip-hash
 cosign  verify-blob "Python-${CPYTHON_VERSION}.tar.xz" --bundle "Python-${CPYTHON_VERSION}.tar.xz.sigstore" --certificate-identity="${CERT_IDENTITY}" --certificate-oidc-issuer="${CERT_OIDC_ISSUER}"
 
 tar -xJf "Python-${CPYTHON_VERSION}.tar.xz"

--- a/docker/build_scripts/build-curl.sh
+++ b/docker/build_scripts/build-curl.sh
@@ -41,8 +41,7 @@ if [ -d /opt/_internal ]; then
 	fi
 fi
 
-fetch_source "${CURL_ROOT}.tar.gz" "${CURL_DOWNLOAD_URL}"
-check_sha256sum "${CURL_ROOT}.tar.gz" "${CURL_HASH}"
+fetch_source "${CURL_ROOT}.tar.gz" "${CURL_DOWNLOAD_URL}" "${CURL_HASH}"
 tar -xzf "${CURL_ROOT}.tar.gz"
 pushd "${CURL_ROOT}"
 ./configure --prefix=${PREFIX} --disable-static --without-libpsl --with-openssl CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS} -Wl,-rpath=\$(LIBRPATH) ${OPENSSL_LDFLAGS}" > /dev/null

--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -46,8 +46,7 @@ check_var "${GIT_ROOT}"
 check_var "${GIT_HASH}"
 check_var "${GIT_DOWNLOAD_URL}"
 
-fetch_source "${GIT_ROOT}.tar.gz" "${GIT_DOWNLOAD_URL}"
-check_sha256sum "${GIT_ROOT}.tar.gz" "${GIT_HASH}"
+fetch_source "${GIT_ROOT}.tar.gz" "${GIT_DOWNLOAD_URL}" "${GIT_HASH}"
 tar -xzf "${GIT_ROOT}.tar.gz"
 pushd "${GIT_ROOT}"
 make install \

--- a/docker/build_scripts/build-mpdecimal.sh
+++ b/docker/build_scripts/build-mpdecimal.sh
@@ -18,8 +18,7 @@ check_var "${MPDECIMAL_DOWNLOAD_URL}"
 
 PREFIX=/opt/_internal/${MPDECIMAL_ROOT%%.*}
 
-fetch_source "${MPDECIMAL_ROOT}.tar.gz" "${MPDECIMAL_DOWNLOAD_URL}"
-check_sha256sum "${MPDECIMAL_ROOT}.tar.gz" "${MPDECIMAL_HASH}"
+fetch_source "${MPDECIMAL_ROOT}.tar.gz" "${MPDECIMAL_DOWNLOAD_URL}" "${MPDECIMAL_HASH}"
 tar xfz "${MPDECIMAL_ROOT}.tar.gz"
 pushd "${MPDECIMAL_ROOT}"
 # add rpath

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -52,8 +52,7 @@ if [ "${AUDITWHEEL_ARCH}" == "i686" ]; then
 	LIBATOMIC=-latomic
 fi
 
-fetch_source "${OPENSSL_ROOT}.tar.gz" "${OPENSSL_DOWNLOAD_URL}"
-check_sha256sum "${OPENSSL_ROOT}.tar.gz" "${OPENSSL_HASH}"
+fetch_source "${OPENSSL_ROOT}.tar.gz" "${OPENSSL_DOWNLOAD_URL}" "${OPENSSL_HASH}"
 tar -xzf "${OPENSSL_ROOT}.tar.gz"
 pushd "${OPENSSL_ROOT}"
 ./Configure "--prefix=${PREFIX}" "--openssldir=${PREFIX}" --libdir=lib no-afalgeng CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" CXXFLAGS="${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS} -Wl,-rpath,\$(LIBRPATH) ${LIBATOMIC}" > /dev/null

--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -17,8 +17,7 @@ PREFIX=/opt/_internal/sqlite3
 check_var "${SQLITE_AUTOCONF_ROOT}"
 check_var "${SQLITE_AUTOCONF_HASH}"
 check_var "${SQLITE_AUTOCONF_DOWNLOAD_URL}"
-fetch_source "${SQLITE_AUTOCONF_ROOT}.tar.gz" "${SQLITE_AUTOCONF_DOWNLOAD_URL}"
-check_sha256sum "${SQLITE_AUTOCONF_ROOT}.tar.gz" "${SQLITE_AUTOCONF_HASH}"
+fetch_source "${SQLITE_AUTOCONF_ROOT}.tar.gz" "${SQLITE_AUTOCONF_DOWNLOAD_URL}" "${SQLITE_AUTOCONF_HASH}"
 tar xfz "${SQLITE_AUTOCONF_ROOT}.tar.gz"
 pushd "${SQLITE_AUTOCONF_ROOT}"
 # add rpath

--- a/docker/build_scripts/build-tcltk.sh
+++ b/docker/build_scripts/build-tcltk.sh
@@ -27,10 +27,8 @@ else
 	exit 0
 fi
 
-fetch_source "${TCL_ROOT}-src.tar.gz" "${TCL_DOWNLOAD_URL}"
-check_sha256sum "${TCL_ROOT}-src.tar.gz" "${TCL_HASH}"
-fetch_source "${TK_ROOT}-src.tar.gz" "${TCL_DOWNLOAD_URL}"
-check_sha256sum "${TK_ROOT}-src.tar.gz" "${TK_HASH}"
+fetch_source "${TCL_ROOT}-src.tar.gz" "${TCL_DOWNLOAD_URL}" "${TCL_HASH}"
+fetch_source "${TK_ROOT}-src.tar.gz" "${TCL_DOWNLOAD_URL}" "${TK_HASH}"
 
 tar xfz "${TCL_ROOT}-src.tar.gz"
 pushd "${TCL_ROOT}/unix"

--- a/docker/build_scripts/build-zstd.sh
+++ b/docker/build_scripts/build-zstd.sh
@@ -19,8 +19,7 @@ ZSTD_ROOT="zstd-${ZSTD_VERSION}"
 
 PREFIX=/opt/_internal/${ZSTD_ROOT%%.*}
 
-fetch_source "${ZSTD_ROOT}.tar.gz" "${ZSTD_DOWNLOAD_URL}/v${ZSTD_VERSION}"
-check_sha256sum "${ZSTD_ROOT}.tar.gz" "${ZSTD_HASH}"
+fetch_source "${ZSTD_ROOT}.tar.gz" "${ZSTD_DOWNLOAD_URL}/v${ZSTD_VERSION}" "${ZSTD_HASH}"
 tar xfz "${ZSTD_ROOT}.tar.gz"
 pushd "${ZSTD_ROOT}/lib"
 # add rpath

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -51,23 +51,19 @@ function fetch_source {
 	check_var "${file}"
 	local url=$2
 	check_var "${url}"
+	local sha256=$3
+	check_var "${sha256}"
 	if [ -f "${file}" ]; then
 		echo "${file} exists, skipping fetch"
 	else
 		curl -fsSL --retry 10 -o "${file}" "${url}/${file}"
 	fi
-}
-
-
-function check_sha256sum {
-	local fname=$1
-	check_var "${fname}"
-	local sha256=$2
-	check_var "${sha256}"
-
-	echo "${sha256}  ${fname}" > "${fname}.sha256"
-	sha256sum -c "${fname}.sha256"
-	rm -f "${fname}.sha256"
+	if [ "${sha256}" != "skip-hash" ]; then
+		if ! echo "${sha256}  ${file}" | sha256sum -c -; then
+			rm "${file}"
+			return 1
+		fi
+	fi
 }
 
 # shellcheck disable=SC2120 # optional arguments

--- a/docker/build_scripts/install-autoconf.sh
+++ b/docker/build_scripts/install-autoconf.sh
@@ -30,10 +30,9 @@ if autoconf --version > /dev/null 2>&1; then
 fi
 
 
-if ! fetch_source "${AUTOCONF_ROOT}.tar.gz" "${AUTOCONF_DOWNLOAD_URL}"; then
-	fetch_source "${AUTOCONF_ROOT}.tar.gz" "${AUTOCONF_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}";
+if ! fetch_source "${AUTOCONF_ROOT}.tar.gz" "${AUTOCONF_DOWNLOAD_URL}" "${AUTOCONF_HASH}"; then
+	fetch_source "${AUTOCONF_ROOT}.tar.gz" "${AUTOCONF_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}" "${AUTOCONF_HASH}"
 fi
-check_sha256sum "${AUTOCONF_ROOT}.tar.gz" "${AUTOCONF_HASH}"
 tar -zxf "${AUTOCONF_ROOT}.tar.gz"
 pushd "${AUTOCONF_ROOT}"
 DESTDIR=/manylinux-rootfs do_standard_install

--- a/docker/build_scripts/install-automake.sh
+++ b/docker/build_scripts/install-automake.sh
@@ -32,10 +32,9 @@ fi
 
 SYSTEM_ACLOCAL="$(which aclocal)"
 
-if ! fetch_source "${AUTOMAKE_ROOT}.tar.gz" "${AUTOMAKE_DOWNLOAD_URL}"; then
-	fetch_source "${AUTOMAKE_ROOT}.tar.gz" "${AUTOMAKE_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}";
+if ! fetch_source "${AUTOMAKE_ROOT}.tar.gz" "${AUTOMAKE_DOWNLOAD_URL}" "${AUTOMAKE_HASH}"; then
+	fetch_source "${AUTOMAKE_ROOT}.tar.gz" "${AUTOMAKE_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}" "${AUTOMAKE_HASH}"
 fi
-check_sha256sum "${AUTOMAKE_ROOT}.tar.gz" "${AUTOMAKE_HASH}"
 tar -zxf "${AUTOMAKE_ROOT}.tar.gz"
 pushd "${AUTOMAKE_ROOT}"
 DESTDIR=/manylinux-rootfs do_standard_install

--- a/docker/build_scripts/install-git-lfs.sh
+++ b/docker/build_scripts/install-git-lfs.sh
@@ -31,8 +31,8 @@ fi
 
 tar -Ozxf "${MY_DIR}/git-lfs-core-gpg-keys" | gpg --import -
 
-curl -fsSL --retry 10 -o "${GIT_LFS_SHA256}" "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/sha256sums.asc"
-curl -fsSL --retry 10 -o "${GIT_LFS_ARCHIVE}" "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_ARCHIVE}"
+fetch_source "${GIT_LFS_SHA256}" "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}" skip-hash
+fetch_source "${GIT_LFS_ARCHIVE}" "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}" skip-hash
 
 gpg -d "${GIT_LFS_SHA256}" | grep "${GIT_LFS_ARCHIVE}" | sha256sum -c
 if [ "${AUDITWHEEL_POLICY}" != "manylinux2014" ]; then

--- a/docker/build_scripts/install-libtool.sh
+++ b/docker/build_scripts/install-libtool.sh
@@ -15,10 +15,9 @@ source "${MY_DIR}/build_utils.sh"
 check_var "${LIBTOOL_ROOT}"
 check_var "${LIBTOOL_HASH}"
 check_var "${LIBTOOL_DOWNLOAD_URL}"
-if ! fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL}"; then
-	fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}";
+if ! fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL}" "${LIBTOOL_HASH}"; then
+	fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}" "${LIBTOOL_HASH}"
 fi
-check_sha256sum "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_HASH}"
 tar -zxf "${LIBTOOL_ROOT}.tar.gz"
 pushd "${LIBTOOL_ROOT}"
 DESTDIR=/manylinux-rootfs do_standard_install

--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -27,8 +27,7 @@ if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ]; then
 	MANYLINUX_LDFLAGS="-fuse-ld=ld ${MANYLINUX_LDFLAGS}"
 fi
 
-fetch_source "${LIBXCRYPT_ROOT}.tar.xz" "${LIBXCRYPT_DOWNLOAD_URL}/v${LIBXCRYPT_VERSION}"
-check_sha256sum "${LIBXCRYPT_ROOT}.tar.xz" "${LIBXCRYPT_HASH}"
+fetch_source "${LIBXCRYPT_ROOT}.tar.xz" "${LIBXCRYPT_DOWNLOAD_URL}/v${LIBXCRYPT_VERSION}" "${LIBXCRYPT_HASH}"
 tar xfJ "${LIBXCRYPT_ROOT}.tar.xz"
 pushd "${LIBXCRYPT_ROOT}"
 DESTDIR=/manylinux-rootfs do_standard_install \


### PR DESCRIPTION
Centralize download and SHA256 verification by adding an optional sha256 parameter to `fetch_source`.

Update build scripts to pass the expected hashes where available and use the "skip-hash" sentinel for artifacts validated by other mechanisms (e.g. CPython  via sigstore/cosign and Git LFS via gpg).

Remove the separate `check_sha256sum` helper and its callers. This simplifies fetch logic and avoids duplicate fetch/check calls across build scripts.

This will prevent future accidental use of `fetch_source` without integrity check.