### PR TITLE
chore: remove `check_var`

### DIFF
--- a/docker/build_scripts/build-curl.sh
+++ b/docker/build_scripts/build-curl.sh
@@ -11,22 +11,13 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source-path=SCRIPTDIR
 source "${MY_DIR}/build_utils.sh"
 
-# Install a more recent curl
-check_var "${CURL_ROOT}"
-check_var "${CURL_HASH}"
-check_var "${CURL_DOWNLOAD_URL}"
-
-# Only needed on manylinux2014
+# Install a more recent curl, only needed on manylinux2014
 if [ "${AUDITWHEEL_POLICY}" != "manylinux2014" ]; then
 	echo "skipping installation of ${CURL_ROOT}"
 	exit 0
 fi
 
-if which yum; then
-	yum erase -y curl-devel
-else
-	apk del curl-dev
-fi
+yum erase -y curl-devel
 
 SO_COMPAT=4
 PREFIX=/opt/_internal/curl-${SO_COMPAT}

--- a/docker/build_scripts/build-git.sh
+++ b/docker/build_scripts/build-git.sh
@@ -42,9 +42,6 @@ if [ -d /opt/_internal ]; then
 fi
 
 # Install newest git
-check_var "${GIT_ROOT}"
-check_var "${GIT_HASH}"
-check_var "${GIT_DOWNLOAD_URL}"
 
 fetch_source "${GIT_ROOT}.tar.gz" "${GIT_DOWNLOAD_URL}" "${GIT_HASH}"
 tar -xzf "${GIT_ROOT}.tar.gz"

--- a/docker/build_scripts/build-mpdecimal.sh
+++ b/docker/build_scripts/build-mpdecimal.sh
@@ -12,9 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "${MY_DIR}/build_utils.sh"
 
 # Install a more recent mpdecimal
-check_var "${MPDECIMAL_ROOT}"
-check_var "${MPDECIMAL_HASH}"
-check_var "${MPDECIMAL_DOWNLOAD_URL}"
 
 PREFIX=/opt/_internal/${MPDECIMAL_ROOT%%.*}
 

--- a/docker/build_scripts/build-openssl.sh
+++ b/docker/build_scripts/build-openssl.sh
@@ -12,9 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "${MY_DIR}/build_utils.sh"
 
 # Install a more recent openssl
-check_var "${OPENSSL_ROOT}"
-check_var "${OPENSSL_HASH}"
-check_var "${OPENSSL_DOWNLOAD_URL}"
 
 OPENSSL_VERSION=${OPENSSL_ROOT#*-}
 OPENSSL_MIN_VERSION=1.1.1

--- a/docker/build_scripts/build-sqlite3.sh
+++ b/docker/build_scripts/build-sqlite3.sh
@@ -14,9 +14,6 @@ source "${MY_DIR}/build_utils.sh"
 PREFIX=/opt/_internal/sqlite3
 
 # Install a more recent SQLite3
-check_var "${SQLITE_AUTOCONF_ROOT}"
-check_var "${SQLITE_AUTOCONF_HASH}"
-check_var "${SQLITE_AUTOCONF_DOWNLOAD_URL}"
 fetch_source "${SQLITE_AUTOCONF_ROOT}.tar.gz" "${SQLITE_AUTOCONF_DOWNLOAD_URL}" "${SQLITE_AUTOCONF_HASH}"
 tar xfz "${SQLITE_AUTOCONF_ROOT}.tar.gz"
 pushd "${SQLITE_AUTOCONF_ROOT}"

--- a/docker/build_scripts/build-tcltk.sh
+++ b/docker/build_scripts/build-tcltk.sh
@@ -13,11 +13,6 @@ source "${MY_DIR}/build_utils.sh"
 
 # Install a more recent Tcl/Tk 8.6
 # https://www.tcl.tk/software/tcltk/download.html
-check_var "${TCL_ROOT}"
-check_var "${TCL_HASH}"
-check_var "${TCL_DOWNLOAD_URL}"
-check_var "${TK_ROOT}"
-check_var "${TK_HASH}"
 
 if [ "${AUDITWHEEL_POLICY}" == "manylinux2014" ] ; then
 	yum erase -y tcl tk

--- a/docker/build_scripts/build-zstd.sh
+++ b/docker/build_scripts/build-zstd.sh
@@ -12,9 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "${MY_DIR}/build_utils.sh"
 
 # Install a more recent mpdecimal
-check_var "${ZSTD_VERSION}"
-check_var "${ZSTD_HASH}"
-check_var "${ZSTD_DOWNLOAD_URL}"
 ZSTD_ROOT="zstd-${ZSTD_VERSION}"
 
 PREFIX=/opt/_internal/${ZSTD_ROOT%%.*}

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -36,23 +36,12 @@ case "${OS_ID_LIKE}" in
 	*) echo "unsupported image"; exit 1;;
 esac
 
-function check_var {
-	if [ -z "$1" ]; then
-		echo "required variable not defined"
-		exit 1
-	fi
-}
-
-
 function fetch_source {
 	# This is called both inside and outside the build context (e.g. in Travis) to prefetch
 	# source tarballs, where curl exists (and works)
-	local file=$1
-	check_var "${file}"
-	local url=$2
-	check_var "${url}"
-	local sha256=$3
-	check_var "${sha256}"
+	local file="$1"
+	local url="$2"
+	local sha256="$3"
 	if [ -f "${file}" ]; then
 		echo "${file} exists, skipping fetch"
 	else

--- a/docker/build_scripts/install-autoconf.sh
+++ b/docker/build_scripts/install-autoconf.sh
@@ -13,9 +13,6 @@ source "${MY_DIR}/build_utils.sh"
 
 
 # Install newest autoconf
-check_var "${AUTOCONF_ROOT}"
-check_var "${AUTOCONF_HASH}"
-check_var "${AUTOCONF_DOWNLOAD_URL}"
 
 AUTOCONF_VERSION=${AUTOCONF_ROOT#*-}
 if autoconf --version > /dev/null 2>&1; then

--- a/docker/build_scripts/install-automake.sh
+++ b/docker/build_scripts/install-automake.sh
@@ -12,9 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "${MY_DIR}/build_utils.sh"
 
 # Install newest automake
-check_var "${AUTOMAKE_ROOT}"
-check_var "${AUTOMAKE_HASH}"
-check_var "${AUTOMAKE_DOWNLOAD_URL}"
 
 AUTOMAKE_VERSION=${AUTOMAKE_ROOT#*-}
 if automake --version > /dev/null 2>&1; then

--- a/docker/build_scripts/install-libtool.sh
+++ b/docker/build_scripts/install-libtool.sh
@@ -12,9 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "${MY_DIR}/build_utils.sh"
 
 # Install newest libtool
-check_var "${LIBTOOL_ROOT}"
-check_var "${LIBTOOL_HASH}"
-check_var "${LIBTOOL_DOWNLOAD_URL}"
 if ! fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL}" "${LIBTOOL_HASH}"; then
 	fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL/ftpmirror.gnu.org/mirrors.ocf.berkeley.edu}" "${LIBTOOL_HASH}"
 fi

--- a/docker/build_scripts/install-libxcrypt.sh
+++ b/docker/build_scripts/install-libxcrypt.sh
@@ -17,9 +17,6 @@ if [ "${AUDITWHEEL_POLICY}" != "manylinux2014" ]; then
 fi
 
 # Install libcrypt.so.1 and libcrypt.so.2
-check_var "${LIBXCRYPT_VERSION}"
-check_var "${LIBXCRYPT_HASH}"
-check_var "${LIBXCRYPT_DOWNLOAD_URL}"
 LIBXCRYPT_ROOT="libxcrypt-${LIBXCRYPT_VERSION}"
 
 if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ]; then


### PR DESCRIPTION
Drop repetitive `check_var` validations from multiple build/install scripts and remove the `check_var` function.

An undefined variable will just fail given `set -exuo pipefail` in each script. An empty variable will fail the build with an easy enough message to debug.