### PR TITLE
chore: handle armv7l clang builds with frame pointers on CPython 3.15+

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -116,10 +116,6 @@ if [ "${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON:-}" == "" ]; then
 			# s390x) MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1;; # gcc is Tier-3, clang not supported at all, gcc is too slow, use clang anyway
 			*) ;;
 		esac
-	elif [ "${POLICY:0:9}-${PLATFORM}" == "musllinux-armv7l" ]; then
-		# when build with clang, extra options are used to build extensions that are not compatible
-		# with gcc so build musllinux-armv7l with gcc rather than clang
-		MANYLINUX_DISABLE_CLANG_FOR_CPYTHON=1
 	fi
 fi
 if [ "${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON}" != "0" ]; then

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -77,8 +77,8 @@ fi
 # CONFIGURE_ARGS+=("--without-frame-pointers")
 if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ] && [ "${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON}" -eq 0 ]; then
 	case "${BASE_POLICY}_${AUDITWHEEL_ARCH}" in
-	  *_armv7l) PATCH_OMIT_LEAF_FRAME_POINTER=1;;
-	  *) PATCH_OMIT_LEAF_FRAME_POINTER=0;;
+	  *_armv7l) PATCH_OMIT_LEAF_FRAME_POINTER=1; PATCH_NO_THUMB=1;;
+	  *) PATCH_OMIT_LEAF_FRAME_POINTER=0; PATCH_NO_THUMB=0;;
 	esac
 	case "${CPYTHON_VERSION}" in
 		3.9.*|3.10.*|3.11.*|3.12.*|3.13.*|3.14.*) PATCH_OMIT_LEAF_FRAME_POINTER=0;;
@@ -89,6 +89,12 @@ if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ] && [ "${MANYLINUX_DISABLE_CLANG_FOR_CP
 		sed -i 's/frame_pointer_cflags -mno-omit-leaf-frame-pointer/frame_pointer_cflags/g' ./configure
 		# we still want to build the interpreter & stdlib modules with "-mno-omit-leaf-frame-pointer"
 		CFLAGS_NODIST="${CFLAGS_NODIST} -mno-omit-leaf-frame-pointer"
+	fi
+	if [ ${PATCH_NO_THUMB} -ne 0 ]; then
+		# patch configure when appending "-mno-thumb"
+		sed -i 's/frame_pointer_cflags -mno-thumb/frame_pointer_cflags/g' ./configure
+		# we still want to build the interpreter & stdlib modules with "-mno-thumb"
+		CFLAGS_NODIST="${CFLAGS_NODIST} -mno-thumb"
 	fi
 fi
 

--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -35,6 +35,8 @@ tar -xJf "Python-${CPYTHON_VERSION}.tar.xz"
 pushd "Python-${CPYTHON_VERSION}"
 PREFIX="/opt/_internal/cpython-${CPYTHON_VERSION}"
 mkdir -p "${PREFIX}/lib"
+
+CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}"
 LDFLAGS_EXTRA=""
 CONFIGURE_ARGS=(--disable-shared --with-ensurepip=no)
 
@@ -68,6 +70,28 @@ if [ "${OPENSSL_PREFIX}" != "" ]; then
 	esac
 fi
 
+# gcc: error: unrecognized command-line option ‘-mno-omit-leaf-frame-pointer’
+# https://github.com/pypa/manylinux/issues/1938
+# let's patch when building with clang to allow building extensions with gcc
+# as we don't want to build without frame pointers altogether which would be
+# CONFIGURE_ARGS+=("--without-frame-pointers")
+if [ "${MANYLINUX_DISABLE_CLANG}" -eq 0 ] && [ "${MANYLINUX_DISABLE_CLANG_FOR_CPYTHON}" -eq 0 ]; then
+	case "${BASE_POLICY}_${AUDITWHEEL_ARCH}" in
+	  *_armv7l) PATCH_OMIT_LEAF_FRAME_POINTER=1;;
+	  *) PATCH_OMIT_LEAF_FRAME_POINTER=0;;
+	esac
+	case "${CPYTHON_VERSION}" in
+		3.9.*|3.10.*|3.11.*|3.12.*|3.13.*|3.14.*) PATCH_OMIT_LEAF_FRAME_POINTER=0;;
+		*) ;;
+	esac
+	if [ ${PATCH_OMIT_LEAF_FRAME_POINTER} -ne 0 ]; then
+		# patch configure when appending "-mno-omit-leaf-frame-pointer"
+		sed -i 's/frame_pointer_cflags -mno-omit-leaf-frame-pointer/frame_pointer_cflags/g' ./configure
+		# we still want to build the interpreter & stdlib modules with "-mno-omit-leaf-frame-pointer"
+		CFLAGS_NODIST="${CFLAGS_NODIST} -mno-omit-leaf-frame-pointer"
+	fi
+fi
+
 unset _PYTHON_HOST_PLATFORM
 
 # configure with hardening options only for the interpreter & stdlib C extensions
@@ -75,7 +99,7 @@ unset _PYTHON_HOST_PLATFORM
 ./configure \
 	CC=gcc \
 	CXX=g++ \
-	CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}" \
+	CFLAGS_NODIST="${CFLAGS_NODIST}" \
 	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS} ${LDFLAGS_EXTRA}" \
 	"--prefix=${PREFIX}" "${CONFIGURE_ARGS[@]}" > /dev/null
 make > /dev/null


### PR DESCRIPTION
Remove the musllinux-armv7l special-case that forced disabling clang in `build.sh` and add logic in `docker/build_scripts/build-cpython.sh` to handle the `-mno-omit-leaf-frame-pointer` & `-mno-thumb` flag.

Define `CFLAGS_NODIST` earlier, and when clang is enabled and building for armv7l (except for CPython 3.9–3.14), patch `configure` to avoid appending `-mno-omit-leaf-frame-pointer` & `-mno-thumb` to distribution builds (so gcc won't see the unrecognized option) while still adding it to `CFLAGS_NODIST` for the interpreter and stdlib modules.

Also update the `configure` invocation to use the new variable.