### PR TITLE
Update hardening compiler flags to prevent breakage on systems where Shadow Stack is enabled

### DIFF
--- a/docker/build_scripts/build-cpython.sh
+++ b/docker/build_scripts/build-cpython.sh
@@ -36,7 +36,7 @@ pushd "Python-${CPYTHON_VERSION}"
 PREFIX="/opt/_internal/cpython-${CPYTHON_VERSION}"
 mkdir -p "${PREFIX}/lib"
 
-CFLAGS_NODIST="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}"
+CFLAGS_NODIST=""
 LDFLAGS_EXTRA=""
 CONFIGURE_ARGS=(--disable-shared --with-ensurepip=no)
 
@@ -115,13 +115,15 @@ fi
 
 unset _PYTHON_HOST_PLATFORM
 
-# configure with hardening options only for the interpreter & stdlib C extensions
-# do not change the default for user built extension (yet?)
+# configure with hardening options for the interpreter & stdlib C extensions and
+# for user built extension
 ./configure \
 	CC=gcc \
 	CXX=g++ \
+	CFLAGS="${MANYLINUX_CFLAGS} ${MANYLINUX_CPPFLAGS}" \
 	CFLAGS_NODIST="${CFLAGS_NODIST}" \
-	LDFLAGS_NODIST="${MANYLINUX_LDFLAGS} ${LDFLAGS_EXTRA}" \
+	LDFLAGS="${MANYLINUX_LDFLAGS}" \
+	LDFLAGS_NODIST="${LDFLAGS_EXTRA}" \
 	"--prefix=${PREFIX}" "${CONFIGURE_ARGS[@]}" > /dev/null
 make > /dev/null
 make install > /dev/null

--- a/docker/build_scripts/build_utils.sh
+++ b/docker/build_scripts/build_utils.sh
@@ -2,13 +2,26 @@
 # Helper utilities for build
 
 
-# use all flags used by ubuntu 20.04 for hardening builds, dpkg-buildflags --export
+# use all flags used by ubuntu 24.04 for hardening builds:
+# DEB_BUILD_MAINT_OPTIONS='hardening=+all optimize=-lto qa=-framepointer reproducible=-fixdebugpath,-fixfilepath' \
+#   dpkg-buildflags --export
 # other flags mentioned in https://wiki.ubuntu.com/ToolChain/CompilerFlags can't be
 # used because the distros used here are too old
-MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
-MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
-MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=3"
+MANYLINUX_CFLAGS="-g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security"
+MANYLINUX_CXXFLAGS="-g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security"
 MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
+
+case $(uname -m) in
+aarch64)
+	MANYLINUX_CFLAGS="${MANYLINUX_CFLAGS} -mbranch-protection=standard"
+	MANYLINUX_CXXFLAGS="${MANYLINUX_CXXFLAGS} -mbranch-protection=standard"
+	;;
+x86_64)
+	MANYLINUX_CFLAGS="${MANYLINUX_CFLAGS} -fcf-protection"
+	MANYLINUX_CXXFLAGS="${MANYLINUX_CXXFLAGS} -fcf-protection"
+	;;
+esac
 
 if [ "${AUDITWHEEL_POLICY:0:10}" == "musllinux_" ]; then
 	export BASE_POLICY=musllinux

--- a/docker/tests/modules-check.py
+++ b/docker/tests/modules-check.py
@@ -229,8 +229,12 @@ class TestModules(unittest.TestCase):
             in {"manylinux2014", "manylinux_2_28", "manylinux_2_31"}
             else ""
         )
-        ldshared = f"{cc} -shared"
+        hardening_ldflags = "-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
+        ldshared = f"{cc} -shared {hardening_ldflags}"
         ldcxxshared = f"{cxx} -shared"
+        if sys.version_info[:2] >= (3, 12):
+            # Added by https://github.com/python/cpython/pull/123298
+            ldcxxshared = f"{ldcxxshared} {hardening_ldflags}"
         if os.environ["AUDITWHEEL_POLICY"] == "musllinux_1_2" and sys.version_info[:2] >= (3, 15):
             stack = "-Wl,-z,stack-size=1048576"
             ldshared = f"{ldshared} {stack}"


### PR DESCRIPTION
Context: Fedora Linux is considering enabling the Shadow Stack feature
of modern x86_64 CPUs for user-space processes
(https://fedoraproject.org/wiki/Changes/ShadowStack).
Shadow-Stack-enabled processes will refuse to `dlopen()` a shared
library that was built without the `-fcf-protection` compiler option.
This will affect binary Python extensions.

Seize the opportunity to refresh the hardening compiler flags, which
were previously based on Ubuntu 20.04's defaults.

Use the output of `dpkg-buildflags --export` on Ubuntu 24.04 with the
following feature selection:
```
hardening=+all optimize=-lto qa=-framepointer
reproducible=-fixdebugpath,-fixfilepath
```

List of changes:
* Increase `_FORTIFY_SOURCE` level to 3
* Remove `-Wall` (was this previously set manually?)
* Remove mapping of debug-info prefixes (didn't seem to make much sense)
* Add stack-clash protection
* Add branch protection dependent on the CPU architecture