### PR TITLE
Update downloaded interpreters

### DIFF
--- a/docker/build_scripts/manylinux-interpreters.py
+++ b/docker/build_scripts/manylinux-interpreters.py
@@ -8,12 +8,31 @@ import sys
 from functools import cache
 from pathlib import Path
 
+from packaging.tags import platform_tags
+
 HERE = Path(__file__).parent.resolve(strict=True)
-PYTHON_TAGS = json.loads(HERE.joinpath("python_versions.json").read_text())
 INSTALL_DIR = Path("/opt/python")
 ARCH = os.environ["AUDITWHEEL_ARCH"]
 POLICY = os.environ["AUDITWHEEL_POLICY"]
 NO_CHECK = os.environ.get("MANYLINUX_INTERPRETERS_NO_CHECK", "0") == "1"
+
+
+def load_python_tags():
+    result = json.loads(HERE.joinpath("python_versions.json").read_text())
+    # only keep what's matching the most specific platform tag
+    platform_tags_ = list(platform_tags())
+    python_tags = list(result.keys())
+    for python_tag in python_tags:
+        update = {}
+        for platform_tag in platform_tags_:
+            if platform_tag in result[python_tag]:
+                update = {ARCH: result[python_tag][platform_tag]}
+                break
+        result[python_tag] = update
+    return result
+
+
+PYTHON_TAGS = load_python_tags()
 
 
 def sort_key(tag):

--- a/docker/build_scripts/python_versions.json
+++ b/docker/build_scripts/python_versions.json
@@ -1,74 +1,84 @@
 {
   "graalpy311-graalpy242_311_native": {
-    "x86_64": {
+    "manylinux_2_17_x86_64": {
       "version": "24.2.2",
       "download_url": "https://github.com/oracle/graalpython/releases/download/graal-24.2.2/graalpy-24.2.2-linux-amd64.tar.gz",
       "sha256": "604b7abf6c58038a30866e52da43818af63bcd97909af8b1a96523c7f0e01414"
     },
-    "aarch64": {
+    "manylinux_2_17_aarch64": {
       "version": "24.2.2",
       "download_url": "https://github.com/oracle/graalpython/releases/download/graal-24.2.2/graalpy-24.2.2-linux-aarch64.tar.gz",
       "sha256": "c9be459ab9479892b88dd63f8f88cbc7b1067f4cb27ff17f4761b36de6bd73af"
     }
   },
   "graalpy312-graalpy250_312_native": {
-    "x86_64": {
+    "manylinux_2_17_x86_64": {
       "version": "25.0.3",
       "download_url": "https://github.com/oracle/graalpython/releases/download/graal-25.0.3/graalpy-25.0.3-linux-amd64.tar.gz",
       "sha256": "c351b503d212519ad5e7e835fd9eb56b557ca9d5b6ef59e32b40435603f90bf8"
     },
-    "aarch64": {
+    "manylinux_2_17_aarch64": {
       "version": "25.0.3",
       "download_url": "https://github.com/oracle/graalpython/releases/download/graal-25.0.3/graalpy-25.0.3-linux-aarch64.tar.gz",
       "sha256": "f889a02425b0b55a0f070d63324f3d08e0975ea0b33aa69041c14418cf6cdeec"
+    },
+    "manylinux_2_28_x86_64": {
+      "version": "25.2.4",
+      "download_url": "https://github.com/oracle/graalpython/releases/download/graal-25.2.4/graalpy3.12-25.2.4-linux-amd64.tar.gz",
+      "sha256": "b3d0766ae6d55daa15f0db1f6c884383d7eec506b186d0ba2f702523a78ff28d"
+    },
+    "manylinux_2_28_aarch64": {
+      "version": "25.2.4",
+      "download_url": "https://github.com/oracle/graalpython/releases/download/graal-25.2.4/graalpy3.12-25.2.4-linux-aarch64.tar.gz",
+      "sha256": "e57472272b1b659ae6ac972117723b0515a49cc9577688ed5563919793170d67"
     }
   },
   "pp39-pypy39_pp73": {
-    "x86_64": {
+    "manylinux_2_17_x86_64": {
       "version": "7.3.16",
       "download_url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux64.tar.bz2",
       "sha256": "16f9c5b808c848516e742986e826b833cdbeda09ad8764e8704595adbe791b23"
     },
-    "aarch64": {
+    "manylinux_2_17_aarch64": {
       "version": "7.3.16",
       "download_url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-aarch64.tar.bz2",
       "sha256": "de3f2ed3581b30555ac0dd3e4df78a262ec736a36fb2e8f28259f8539b278ef4"
     },
-    "i686": {
+    "manylinux_2_17_i686": {
       "version": "7.3.16",
       "download_url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux32.tar.bz2",
       "sha256": "583b6d6dd4e8c07cbc04da04a7ec2bdfa6674825289c2378c5e018d5abe779ea"
     }
   },
   "pp310-pypy310_pp73": {
-    "x86_64": {
+    "manylinux_2_17_x86_64": {
       "version": "7.3.19",
       "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.19-linux64.tar.bz2",
       "sha256": "c73ac2cc2380ac9227fd297482bf2a3e17a80618ba46db7544d535515321ec1e"
     },
-    "aarch64": {
+    "manylinux_2_17_aarch64": {
       "version": "7.3.19",
       "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.19-aarch64.tar.bz2",
       "sha256": "af27a589178f11198e2244ab65ca510630ba97c131d7ccc4021eb5bc58de7f57"
     },
-    "i686": {
+    "manylinux_2_17_i686": {
       "version": "7.3.19",
       "download_url": "https://downloads.python.org/pypy/pypy3.10-v7.3.19-linux32.tar.bz2",
       "sha256": "e63a4fcad2641ee541e852918befb513abf04ce7070f743a50778cae9f9da80e"
     }
   },
   "pp311-pypy311_pp73": {
-    "x86_64": {
+    "manylinux_2_17_x86_64": {
       "version": "7.3.23",
       "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux64.tar.bz2",
       "sha256": "16f9f56e82d1f4ec95a324c1a8cacfd78afc7f0656c0a809a18725ef4391453a"
     },
-    "aarch64": {
+    "manylinux_2_17_aarch64": {
       "version": "7.3.23",
       "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-aarch64.tar.bz2",
       "sha256": "5433ac0ad526aeb35025ef8509bed65cd62ea35cb9e21ac649c69a5eff4eecb6"
     },
-    "i686": {
+    "manylinux_2_17_i686": {
       "version": "7.3.23",
       "download_url": "https://downloads.python.org/pypy/pypy3.11-v7.3.23-linux32.tar.bz2",
       "sha256": "c7e2ffb173dcadbe4708a2e606e0b705474c1c33f25a09a4084f265d538172e4"

--- a/tools/update_interpreters_download.py
+++ b/tools/update_interpreters_download.py
@@ -1,5 +1,5 @@
 # /// script
-# dependencies = ["packaging", "requests"]
+# dependencies = ["packaging>=24.2", "requests"]
 # ///
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from hashlib import sha256
 from pathlib import Path
 
 import requests
-from packaging.specifiers import Specifier
+from packaging.specifiers import Specifier, SpecifierSet
 from packaging.version import Version
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve(strict=True)
@@ -28,8 +28,24 @@ def get_sha256(url: str) -> str:
     return sha256sum.hexdigest()
 
 
-def update_pypy_version(releases, py_spec, pp_spec, tag, arch, version_dict, updates):
-    pypy_arch = {"x86_64": "x64"}.get(arch, arch)
+def update_pypy_version(
+    releases,
+    py_spec: Specifier,
+    pp_spec: Specifier,
+    tag: str,
+    platform_tag: str,
+    version_dict: dict[str, str],
+    updates: list[str],
+):
+    if platform_tag.endswith("_x86_64"):
+        pypy_arch = "x64"
+    elif platform_tag.endswith("_aarch64"):
+        pypy_arch = "aarch64"
+    elif platform_tag.endswith("_i686"):
+        pypy_arch = "i686"
+    else:
+        msg = f"unknown platform mapping for PyPy: {platform_tag}"
+        raise LookupError(msg)
     current_version = None
     if "version" in version_dict:
         current_version = Version(version_dict["version"])
@@ -46,7 +62,7 @@ def update_pypy_version(releases, py_spec, pp_spec, tag, arch, version_dict, upd
             )
         except StopIteration:
             continue
-        message = f"updating {tag} {arch} to {r['pypy_version']}"
+        message = f"updating {tag} {platform_tag} to {r['pypy_version']}"
         print(message)
         version_dict["version"] = str(r["pypy_version"])
         version_dict["download_url"] = file["download_url"]
@@ -55,7 +71,7 @@ def update_pypy_version(releases, py_spec, pp_spec, tag, arch, version_dict, upd
         break
 
 
-def update_pypy_versions(versions, updates):
+def update_pypy_versions(versions: dict[str, dict[str, dict[str, str]]], updates: list[str]):
     response = requests.get("https://downloads.python.org/pypy/versions.json")
     response.raise_for_status()
     releases = [r for r in response.json() if r["pypy_version"] != "nightly"]
@@ -71,7 +87,7 @@ def update_pypy_versions(versions, updates):
     ]
     releases.sort(key=lambda r: r["pypy_version"], reverse=True)
 
-    for tag in versions:
+    for tag, platform_versions in versions.items():
         if not tag.startswith("pp"):
             continue
         python_tag, abi_tag = tag.split("-")
@@ -84,12 +100,33 @@ def update_pypy_versions(versions, updates):
         pp_minor = int(pp_ver[3:])
         py_spec = Specifier(f"=={py_major}.{py_minor}.*")
         pp_spec = Specifier(f"=={pp_major}.{pp_minor}.*")
-        for arch in versions[tag]:
-            update_pypy_version(releases, py_spec, pp_spec, tag, arch, versions[tag][arch], updates)
+        for platform_tag in platform_versions:
+            update_pypy_version(
+                releases,
+                py_spec,
+                pp_spec,
+                tag,
+                platform_tag,
+                platform_versions[platform_tag],
+                updates,
+            )
 
 
-def update_graalpy_version(releases, graalpy_spec, tag, arch, version_dict, updates):
-    graalpy_arch = re.escape({"x86_64": "amd64"}.get(arch, arch))
+def update_graalpy_version(
+    releases,
+    graalpy_specs: SpecifierSet,
+    tag: str,
+    platform_tag: str,
+    version_dict: dict[str, str],
+    updates: list[str],
+):
+    if platform_tag.endswith("_x86_64"):
+        graalpy_arch = "amd64"
+    elif platform_tag.endswith("_aarch64"):
+        graalpy_arch = "aarch64"
+    else:
+        msg = f"unknown platform mapping for GraalPy: {platform_tag}"
+        raise LookupError(msg)
     asset_re = re.compile(
         rf"graalpy(?:\d+\.\d+)?-(?P<version>\d+\.\d+\.\d+)-linux-{graalpy_arch}\.tar\.gz"
     )
@@ -100,7 +137,7 @@ def update_graalpy_version(releases, graalpy_spec, tag, arch, version_dict, upda
         version = Version(r["tag_name"].split("-")[1])
         if current_version is not None and current_version >= version:
             continue
-        if not graalpy_spec.contains(version):
+        if not graalpy_specs.contains(version):
             continue
         asset_found = False
         for asset in r["assets"]:
@@ -110,16 +147,20 @@ def update_graalpy_version(releases, graalpy_spec, tag, arch, version_dict, upda
                 break
         if not asset_found:
             continue
-        message = f"updating {tag} {arch} to {version}"
+        message = f"updating {tag} {platform_tag} to {version}"
         print(message)
+        download_url = asset["browser_download_url"]
+        sha256_url = f"{download_url}.sha256"
         version_dict["version"] = str(version)
-        version_dict["download_url"] = asset["browser_download_url"]
-        version_dict["sha256"] = get_sha256(asset["browser_download_url"])
+        version_dict["download_url"] = download_url
+        sha256_response = requests.get(sha256_url)
+        sha256_response.raise_for_status()
+        version_dict["sha256"] = sha256_response.text.strip()
         updates.append(message)
         break
 
 
-def get_next_page_link(response):
+def get_next_page_link(response: requests.Response) -> str | None:
     link = response.headers.get("link")
     if link:
         for part in re.split(r"\s*,\s*", link):
@@ -131,7 +172,7 @@ def get_next_page_link(response):
     return None
 
 
-def update_graalpy_versions(versions, updates):
+def update_graalpy_versions(versions: dict[str, dict[str, dict[str, str]]], updates: list[str]):
     releases = []
     url = "https://api.github.com/repos/oracle/graalpython/releases"
     while url:
@@ -139,7 +180,7 @@ def update_graalpy_versions(versions, updates):
         response.raise_for_status()
         releases += response.json()
         url = get_next_page_link(response)
-    for tag in versions:
+    for tag, platform_versions in versions.items():
         if not tag.startswith("graalpy"):
             continue
         _, abi_tag = tag.split("-")
@@ -147,18 +188,24 @@ def update_graalpy_versions(versions, updates):
         assert graalpy_ver.startswith("graalpy")
         graalpy_ver = graalpy_ver[len("graalpy") :]
         graalpy_major = int(graalpy_ver[:2])
-        graalpy_minor = int(graalpy_ver[2:])
-        graalpy_spec = Specifier(f"=={graalpy_major}.{graalpy_minor}.*")
-        for arch in versions[tag]:
-            update_graalpy_version(releases, graalpy_spec, tag, arch, versions[tag][arch], updates)
+        graalpy_spec = Specifier(f"=={graalpy_major}.*")
+        graalpy_spec_ml_2_17 = Specifier("<25.1")
+        for platform_tag in platform_versions:
+            if platform_tag.startswith("manylinux_2_17_"):
+                graalpy_specs = SpecifierSet((graalpy_spec, graalpy_spec_ml_2_17))
+            else:
+                graalpy_specs = SpecifierSet((graalpy_spec,))
+            update_graalpy_version(
+                releases, graalpy_specs, tag, platform_tag, platform_versions[platform_tag], updates
+            )
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", dest="dry_run", action="store_true", help="dry run")
     args = parser.parse_args()
-    versions = json.loads(PYTHON_VERSIONS.read_text())
-    updates = []
+    versions: dict[str, dict[str, dict[str, str]]] = json.loads(PYTHON_VERSIONS.read_text())
+    updates: list[str] = []
     update_pypy_versions(versions, updates)
     update_graalpy_versions(versions, updates)
     if not args.dry_run:


### PR DESCRIPTION
GraalPy was pinning the minor version but it seems that it's not necessary anymore as 25.1 and 25.2 still get a `graalpy312-graalpy250_312_native` python-abi tag.

GraalPy  25.1 & 25.2 are not supported on manylinux2014 images anymore.