### PR TITLE
chore: use prek instead of pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
 
   build_matrix:
     name: Build matrix

--- a/noxfile.py
+++ b/noxfile.py
@@ -99,5 +99,5 @@ def update_static_clang(session):
 @nox.session(python="3.14", reuse_venv=True)
 def lint(session: nox.Session) -> None:
     """Run linters on the codebase."""
-    session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files")
+    session.install("prek")
+    session.run("prek", "run", "--all-files")


### PR DESCRIPTION
Use prek for the GitHub Actions pre-commit checks (should avoid a node 20 warning, and is fast) and the local nox lint session (fast).

Assisted-by: OpenCode:deepseek-v4-flash
